### PR TITLE
INF-661/feat: enable claude code reviewer

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -1,0 +1,41 @@
+name: Claude Code Review
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  code-review:
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    if: >
+      (github.event_name == 'pull_request_target') ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@claude'))
+    steps:
+      - uses: two-inc/claude-code-reviewer@v4
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_prompt: |
+
+            ## Magento Hyvä Extension Specific Guidelines:
+
+            For this PHP Magento 2 Hyvä theme extension, pay special attention to:
+            - **Hyvä compatibility**: Follow Hyvä theme patterns and component structure
+            - **Alpine.js**: Use Alpine.js for reactivity (Hyvä uses Alpine, not Knockout)
+            - **Tailwind CSS**: Follow Tailwind utility-first patterns for styling
+            - **ViewModels**: Use Hyvä view models instead of traditional Magento blocks
+            - **JavaScript bundling**: Check for proper JS module organization
+            - **Template structure**: Verify .phtml templates follow Hyvä conventions
+            - **Performance**: Ensure changes maintain Hyvä's performance benefits
+            - **Backward compatibility**: Check compatibility with base Magento plugin

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,82 +1,44 @@
-# Magento Hyva Extension
+# Magento Hyvä Extension — AI Agent Context
 
-## Git Workflow
+## Project Overview
 
-- Use `SKIP=commit-msg` when committing on `main` branch (no Linear ticket needed)
-- Do NOT skip commit-msg hook on feature branches
-- Never use `--no-verify` flag
+Hyvä theme extension for Two's Magento plugin, providing modern frontend components using Alpine.js and Tailwind CSS.
 
-## Version Management
+- **Language**: PHP 7.4+ and JavaScript (Alpine.js)
+- **Framework**: Magento 2 module for Hyvä theme
+- **Purpose**: Frontend components for Two BNPL checkout in Hyvä theme
 
-Version bumps are done using `bumpver`:
+## Directory Structure
 
-```bash
-SKIP=commit-msg bumpver update --patch  # or --minor, --major
-git push origin main --tags
+```
+etc/                  # Module configuration
+view/frontend/        # Hyvä frontend templates and layouts
+├── templates/        # .phtml template files
+├── layout/           # XML layout files
+└── web/              # CSS/JS assets
+ViewModel/            # View models for templates
 ```
 
-## Development Tips
+## Development Notes
 
-### Running Commands
+- Built specifically for Hyvä theme (not compatible with Luma)
+- Uses Alpine.js for JavaScript reactivity (not Knockout.js)
+- Tailwind CSS for styling (utility-first approach)
+- View models replace traditional Magento blocks
+- Extends base Two Magento plugin functionality
 
-Most Magento CLI commands should be run as the web server user to avoid permission issues:
-
-```bash
-su www-data -s /bin/bash -c "bin/magento <command>"
-```
-
-## Hyva-specific Quirks
-
-### Tailwind CSS Rebuild
-
-After changing templates, Tailwind CSS must be rebuilt to include new utility classes.
-
-**Important**: New Tailwind classes in templates won't appear until CSS is rebuilt.
-
-### Magewire Components
-
-- Located in `Magewire/` directory
-- Use `wire:model` for two-way binding, `wire:click` for actions
-- Component state persists across requests via session
-- Debug Magewire issues by checking browser Network tab for `livewire/message` requests
-
-### Alpine.js Integration
-
-- Hyva uses Alpine.js for frontend interactivity
-- Use `x-data`, `x-show`, `x-on:click` etc. in templates
-- Alpine components can communicate via `$dispatch` and `@event-name.window`
-
-### Staging Cache Refresh (git-sync workflow)
-
-**IMPORTANT**: Always run Magento CLI commands as www-data user to avoid permission issues:
+## Testing
 
 ```bash
-kubectl exec deploy/magento -n staging -- su www-data -s /bin/bash -c "php bin/magento <command>"
+php bin/magento setup:upgrade       # Apply changes
+php bin/magento cache:flush         # Clear cache
+# Test in browser with Hyvä theme active
 ```
 
-When developing with git-sync on staging, after pushing changes:
+## Common Patterns
 
-1. Wait for git-sync to pull the latest commit:
-
-```bash
-kubectl exec deploy/magento -n staging -c git-sync-hyva -- sh -c "cd /git/code && git log -1 --oneline"
-```
-
-2. Clear cache and restart Apache:
-
-```bash
-kubectl exec deploy/magento -n staging -- bash -c "rm -rf pub/static/frontend/Hyva/*/en_GB/Two_GatewayHyva && php bin/magento cache:flush && apachectl graceful"
-```
-
-Or combined (wait 15s for sync then clear):
-
-```bash
-sleep 15 && kubectl exec deploy/magento -n staging -c git-sync-hyva -- sh -c "cd /git/code && git log -1 --oneline" && kubectl exec deploy/magento -n staging -- bash -c "rm -rf pub/static/frontend/Hyva/*/en_GB/Two_GatewayHyva && php bin/magento cache:flush && apachectl graceful"
-```
-
-### Common Issues
-
-1. **Magewire component not updating**: Check if component class has correct namespace and implements proper interface
-2. **Styles not applying**: Rebuild Tailwind CSS
-3. **Alpine.js not working**: Check browser console for JS errors, ensure `x-data` is on parent element
-4. **Payment method not showing**: Verify `two_payment` is enabled in admin config
+- Use Alpine.js x-data, x-show, x-if directives
+- Tailwind utility classes for styling
+- View models for data preparation
+- Component-based template structure
+- Progressive enhancement approach

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Magento Hyvä Extension — AI Agent Context
+# Magento Hyva Extension
 
 ## Project Overview
 
@@ -17,28 +17,86 @@ view/frontend/        # Hyvä frontend templates and layouts
 ├── layout/           # XML layout files
 └── web/              # CSS/JS assets
 ViewModel/            # View models for templates
+Magewire/             # Magewire components (if applicable)
 ```
 
-## Development Notes
+## Git Workflow
 
-- Built specifically for Hyvä theme (not compatible with Luma)
-- Uses Alpine.js for JavaScript reactivity (not Knockout.js)
-- Tailwind CSS for styling (utility-first approach)
-- View models replace traditional Magento blocks
-- Extends base Two Magento plugin functionality
+- Use `SKIP=commit-msg` when committing on `main` branch (no Linear ticket needed)
+- Do NOT skip commit-msg hook on feature branches
+- Never use `--no-verify` flag
 
-## Testing
+## Version Management
+
+Version bumps are done using `bumpver`:
 
 ```bash
-php bin/magento setup:upgrade       # Apply changes
-php bin/magento cache:flush         # Clear cache
-# Test in browser with Hyvä theme active
+SKIP=commit-msg bumpver update --patch  # or --minor, --major
+git push origin main --tags
 ```
 
-## Common Patterns
+## Development Tips
 
-- Use Alpine.js x-data, x-show, x-if directives
-- Tailwind utility classes for styling
-- View models for data preparation
-- Component-based template structure
-- Progressive enhancement approach
+### Running Commands
+
+Most Magento CLI commands should be run as the web server user to avoid permission issues:
+
+```bash
+su www-data -s /bin/bash -c "bin/magento <command>"
+```
+
+## Hyva-specific Quirks
+
+### Tailwind CSS Rebuild
+
+After changing templates, Tailwind CSS must be rebuilt to include new utility classes.
+
+**Important**: New Tailwind classes in templates won't appear until CSS is rebuilt.
+
+### Magewire Components
+
+- Located in `Magewire/` directory
+- Use `wire:model` for two-way binding, `wire:click` for actions
+- Component state persists across requests via session
+- Debug Magewire issues by checking browser Network tab for `livewire/message` requests
+
+### Alpine.js Integration
+
+- Hyva uses Alpine.js for frontend interactivity
+- Use `x-data`, `x-show`, `x-on:click` etc. in templates
+- Alpine components can communicate via `$dispatch` and `@event-name.window`
+
+### Staging Cache Refresh (git-sync workflow)
+
+**IMPORTANT**: Always run Magento CLI commands as www-data user to avoid permission issues:
+
+```bash
+kubectl exec deploy/magento -n staging -- su www-data -s /bin/bash -c "php bin/magento <command>"
+```
+
+When developing with git-sync on staging, after pushing changes:
+
+1. Wait for git-sync to pull the latest commit:
+
+```bash
+kubectl exec deploy/magento -n staging -c git-sync-hyva -- sh -c "cd /git/code && git log -1 --oneline"
+```
+
+2. Clear cache and restart Apache:
+
+```bash
+kubectl exec deploy/magento -n staging -- bash -c "rm -rf pub/static/frontend/Hyva/*/en_GB/Two_GatewayHyva && php bin/magento cache:flush && apachectl graceful"
+```
+
+Or combined (wait 15s for sync then clear):
+
+```bash
+sleep 15 && kubectl exec deploy/magento -n staging -c git-sync-hyva -- sh -c "cd /git/code && git log -1 --oneline" && kubectl exec deploy/magento -n staging -- bash -c "rm -rf pub/static/frontend/Hyva/*/en_GB/Two_GatewayHyva && php bin/magento cache:flush && apachectl graceful"
+```
+
+### Common Issues
+
+1. **Magewire component not updating**: Check if component class has correct namespace and implements proper interface
+2. **Styles not applying**: Rebuild Tailwind CSS
+3. **Alpine.js not working**: Check browser console for JS errors, ensure `x-data` is on parent element
+4. **Payment method not showing**: Verify `two_payment` is enabled in admin config

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+See @AGENTS.md for codebase context.
+
+When you learn something new worth remembering (patterns, gotchas, conventions), update AGENTS.md with a succinct entry. Link to detailed docs in `docs/` folder where appropriate.


### PR DESCRIPTION
enables claude code reviewer for automated pr reviews

- adds claude-code-review.yaml workflow with codebase-specific extra_prompt
- adds CLAUDE.md and AGENTS.md for ai agent context
- uses oauth token authentication
- triggers on pr open/sync and @claude mentions
- follows pattern from checkout-api

tracking: INF-661