### PR TITLE
INF-661/fix: use @main instead of @v4 for claude-code-reviewer

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -20,7 +20,7 @@ jobs:
        github.event.issue.pull_request &&
        contains(github.event.comment.body, '@claude'))
     steps:
-      - uses: two-inc/claude-code-reviewer@v4
+      - uses: two-inc/claude-code-reviewer@main
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
         with:


### PR DESCRIPTION
fixes claude-code-reviewer to use @main tag instead of @v4

the @v4 tag doesn't exist - should use @main to get latest version

tracking: https://linear.app/tillit/issue/INF-661