### PR TITLE
ABN-362/fix: rename etc/module.xml to ABN namespace

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -7,11 +7,11 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="Two_GatewayHyva" setup_version="1.3.0">
+	<module name="ABN_GatewayHyva" setup_version="1.3.0">
 		<sequence>
             <module name="Hyva_Checkout"/>
             <module name="Hyva_CompatModuleFallback"/>
-            <module name="Two_Gateway" />
+            <module name="ABN_Gateway" />
         </sequence>
 	</module>
 </config>


### PR DESCRIPTION
## Summary

- Renames `etc/module.xml` from `Two_GatewayHyva` → `ABN_GatewayHyva`
- Renames sequence dep from `Two_Gateway` → `ABN_Gateway`
- Closes ABN-362

The ABN layer commit (a0e2519) renamed everything else (PSR-4, payment code, templates, PHP namespaces) but missed `etc/module.xml`. Functionally works because sequence deps are soft and composer pins `magento-abn-plugin`, but the AGENTS.md verification grep flagged the drift.

## Note on the maintenance model

Branch protection on abn-main blocks force-push, so this lands as a separate commit on top of the ABN layer rather than amended into it. On the next main→abn-main rebase, fold this diff into the ABN layer commit (or recreate it as part of the recipe) so the long-term "abn-main = main + 1 commit" model holds.

After this merges, the verification grep is clean:

\`\`\`
rg -i "twoGatewayHyva|two_payment|Two_GatewayHyva|Two\\\\Gateway" --glob '!AGENTS.md'
# (empty)
\`\`\`

## Test plan

- [ ] `composer install` succeeds with the abn-plugin parent
- [ ] `php bin/magento module:status ABN_GatewayHyva` lists the module enabled
- [ ] AGENTS.md verification grep returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)