### PR TITLE
INF-1072/feat: complete dev tooling (FRP, flush, PHPUnit, brand overlay)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ CLAUDE.local.md
 .aider*
 .agent-notes/
 .serena/
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ venv/
 .frpc.pid
 .phpunit.result.cache
 auth.json
+# Brand overlay — only tracked on brand branches (e.g. abn-main).
+# If this file appears on `main`, it's stale from a previous checkout — delete it.
+Makefile.brand
 
 # Node.js
 node_modules/
@@ -23,3 +26,5 @@ node_modules/
 # AI assistants
 CLAUDE.local.md
 .aider*
+.agent-notes/
+.serena/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,31 @@ Magewire/             # Magewire components (if applicable)
 - Do NOT skip commit-msg hook on feature branches
 - Never use `--no-verify` flag
 
+## Branch Model
+
+This repo is the Hyvä UI layer for the Two BNPL Magento plugin. Two branches in parallel:
+
+- `main` — Two-branded (`Two_GatewayHyva`, namespace `Two\GatewayHyva\`, depends on `two-inc/magento2`)
+- `abn-main` — ABN-branded (`ABN_GatewayHyva`, namespace `ABN\GatewayHyva\`, depends on `two-inc/magento-abn-plugin`)
+
+`abn-main` tracks `main` plus a small set of brand-flavor overrides — namespace, payment method code, logo, and a `Makefile.brand` overlay. Historically described as "main + 1 ABN-layer commit"; in practice (since `abn-main` has GitHub branch protection blocking force-push) it is "main + N commits" where each ABN-flavor change adds another commit on top.
+
+When porting features from `magento-abn-plugin`, build on `main` first. The next `abn-main` rebase carries the change forward. ABN-specific assets (logo, `achterafbetalen` URL defaults, ABN store country, GCS publish target) belong only on `abn-main` — see *Brand overlay* below.
+
+## Brand overlay
+
+`main/Makefile` has `-include Makefile.brand` at the top. The file is gitignored on `main` and absent there; on `abn-main` it is tracked and contains brand-flavor overrides:
+
+- API / checkout URL defaults
+- Default store country (`NO` on main, `NL` on ABN)
+- `TWO_BRAND` / `TWO_BRAND_VERSION` defaults
+- `LOG_DIR` override (`var/log/two` on main, `var/log/abn` on ABN)
+- ABN-only targets: `publish` (GCS bucket), `tag` (with `abn` git remote)
+
+`Makefile.brand` MUST appear before any `?=` defaults it intends to override (the `-include` lives at the top of the Makefile for this reason). Brand-side overrides use `:=` so they win against main's `?=`.
+
+If you see a `Makefile.brand` on `main` it is stale — delete it. The Makefile prints `Loaded Makefile.brand — brand overlay active` when an overlay is in scope.
+
 ## Version Management
 
 Version bumps are done using `bumpver`:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,14 @@
 # Development environment
 # ==============================================================================
 
+# Brand overlay (optional). MUST be included before any `?=` defaults below so
+# brand-side `:=` assignments win. Leave alone on `main`. See AGENTS.md → Brand
+# overlay. Present only on brand branches such as `abn-main`.
+-include Makefile.brand
+ifneq (,$(wildcard Makefile.brand))
+$(info Loaded Makefile.brand — brand overlay active)
+endif
+
 -include .env.local
 
 CONTAINER  := magento-hyva
@@ -14,15 +22,20 @@ TWO_ENV              := $(shell gcloud config get-value account 2>/dev/null | gr
 TWO_API_BASE_URL     ?= https://api.$(TWO_ENV).two.inc
 TWO_CHECKOUT_BASE_URL ?= https://checkout.$(TWO_ENV).two.inc
 TWO_STORE_COUNTRY    ?= NO
+TWO_BRAND            ?=
+TWO_BRAND_VERSION    ?=
 HYVA_PACKAGIST_URL   ?= https://hyva-themes.repo.packagist.com
+LOG_DIR              ?= var/log/two
+BRAND                ?= two
 export PORT
 
-.PHONY: help install configure compile run debug stop clean logs proxy archive patch minor major format
+.PHONY: help install configure compile run debug stop clean flush logs proxy archive patch minor major format test
 
 .DEFAULT_GOAL := help
 
 ## Show this help
 help:
+	@echo "Brand: $(BRAND)"
 	@awk '/^## /{desc=substr($$0,4)} /^[a-zA-Z_-]+:/{if(desc){printf "  \033[36m%-16s\033[0m %s\n",$$1,desc; desc=""}}' $(MAKEFILE_LIST)
 
 ## Create Magento container, install plugins and Xdebug
@@ -34,6 +47,8 @@ install: clean
 		-e URL=$(URL) \
 		-e TWO_API_BASE_URL=$(TWO_API_BASE_URL) \
 		-e TWO_CHECKOUT_BASE_URL=$(TWO_CHECKOUT_BASE_URL) \
+		$(if $(TWO_BRAND),-e TWO_BRAND=$(TWO_BRAND)) \
+		$(if $(TWO_BRAND_VERSION),-e TWO_BRAND_VERSION=$(TWO_BRAND_VERSION)) \
 		-v $(CURDIR):/data/extensions/workdir \
 		$(IMAGE):$(TAG)
 	@echo "Waiting for Magento to start..."
@@ -47,6 +62,12 @@ install: clean
 		docker exec $(CONTAINER) php /data/extensions/workdir/dev/stub-hyva; \
 	fi
 	docker exec $(CONTAINER) composer require two-inc/magento2-hyva-checkout:@dev --no-plugins
+	docker exec $(CONTAINER) composer require --no-plugins \
+		community-engineering/language-nl_nl \
+		community-engineering/language-nb_no \
+		community-engineering/language-sv_se \
+		community-engineering/language-fi_fi \
+		community-engineering/language-da_dk
 	docker exec $(CONTAINER) rm -rf /data/generated/code
 	docker exec $(CONTAINER) php bin/magento module:disable Magento_AdminAdobeImsTwoFactorAuth Magento_TwoFactorAuth
 	docker exec $(CONTAINER) php bin/magento module:enable Two_Gateway Two_GatewayHyva
@@ -55,13 +76,22 @@ install: clean
 	docker exec $(CONTAINER) php bin/magento setup:di:compile
 	$(MAKE) configure TWO_API_KEY=$(or $(TWO_API_KEY),dummy-dev-key) TWO_ENV=$(TWO_ENV)
 	docker exec $(CONTAINER) bash /data/extensions/workdir/dev/install-xdebug
-	@echo ""
-	@echo "========================================="
-	@echo " Magento store: $(URL)"
-	@echo " Admin panel:   $(URL)admin"
-	@echo " Credentials:   exampleuser / examplepassword123"
-	@echo " Xdebug:        installed (activate with 'make debug')"
-	@echo "========================================="
+	@./start-proxy.sh --background || true
+	@PROXY_URL=$$(./start-proxy.sh url 2>/dev/null); \
+	if [ -n "$$PROXY_URL" ]; then \
+		docker exec $(CONTAINER) bash /data/extensions/workdir/dev/patch-proxy "$$PROXY_URL" 2>&1 | grep -v Xdebug; \
+	fi; \
+	echo ""; \
+	echo "========================================="; \
+	echo " Magento store: $(URL)"; \
+	echo " Admin panel:   $(URL)admin"; \
+	if [ -n "$$PROXY_URL" ]; then \
+		echo " Proxy store:   $$PROXY_URL/"; \
+		echo " Proxy admin:   $$PROXY_URL/admin"; \
+	fi; \
+	echo " Credentials:   exampleuser / examplepassword123"; \
+	echo " Xdebug:        installed (activate with 'make debug')"; \
+	echo "========================================="
 
 ## Update payment config: make configure TWO_API_KEY=xxx
 configure:
@@ -134,6 +164,15 @@ stop:
 	-docker exec $(CONTAINER) bash /data/extensions/workdir/dev/patch-proxy --reset 2>/dev/null
 	docker stop $(CONTAINER)
 
+## Clear static content and flush caches (frontend + adminhtml JS/CSS/templates)
+flush:
+	docker exec $(CONTAINER) bash -c \
+		"rm -rf pub/static/frontend/* pub/static/adminhtml/* \
+			var/view_preprocessed/pub/static/frontend/* \
+			var/view_preprocessed/pub/static/adminhtml/* \
+		&& php bin/magento cache:flush \
+		&& (apachectl graceful 2>/dev/null || true)"
+
 ## Remove the Magento container and stop proxy
 clean:
 	-./start-proxy.sh stop 2>/dev/null
@@ -144,9 +183,9 @@ clean:
 proxy:
 	./start-proxy.sh
 
-## Tail Two plugin logs
+## Tail plugin logs
 logs:
-	docker exec $(CONTAINER) bash -c 'mkdir -p var/log/two && touch var/log/two/debug.log var/log/two/error.log && chmod -R 777 var/log/two && tail -f var/log/two/debug.log var/log/two/error.log'
+	docker exec $(CONTAINER) bash -c 'mkdir -p $(LOG_DIR) && touch $(LOG_DIR)/debug.log $(LOG_DIR)/error.log && chmod -R 777 $(LOG_DIR) && tail -f $(LOG_DIR)/debug.log $(LOG_DIR)/error.log'
 
 # ==============================================================================
 # Release
@@ -168,3 +207,17 @@ major: bumpver-major
 format:
 	prettier -w view/frontend/templates/
 	prettier -w view/frontend/web/css/
+
+# ==============================================================================
+# Tests
+# ==============================================================================
+
+PHPUNIT_VERSION := 9.6.34
+PHPUNIT_SHA256  := e7264ae61fe58a487c2bd741905b85940d8fbc2b32cf4a279949b6d9a172a06a
+
+## Run PHPUnit tests
+test:
+	docker run --rm -v $(CURDIR):/app -w /app php:8.1-cli bash -c \
+		"php -r \"copy('https://phar.phpunit.de/phpunit-$(PHPUNIT_VERSION).phar', '/tmp/phpunit.phar');\" \
+		&& echo '$(PHPUNIT_SHA256)  /tmp/phpunit.phar' | sha256sum -c - \
+		&& php /tmp/phpunit.phar"

--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,8 @@ install: clean
 	docker exec $(CONTAINER) php bin/magento module:disable Magento_AdminAdobeImsTwoFactorAuth Magento_TwoFactorAuth
 	docker exec $(CONTAINER) php bin/magento module:enable Two_Gateway Two_GatewayHyva
 	docker exec $(CONTAINER) php bin/magento setup:upgrade
-	docker exec $(CONTAINER) php bin/magento deploy:mode:set developer
 	docker exec $(CONTAINER) php bin/magento setup:di:compile
+	docker exec $(CONTAINER) php bin/magento deploy:mode:set developer
 	$(MAKE) configure TWO_API_KEY=$(or $(TWO_API_KEY),dummy-dev-key) TWO_ENV=$(TWO_ENV)
 	docker exec $(CONTAINER) bash /data/extensions/workdir/dev/install-xdebug
 	@./start-proxy.sh --background || true

--- a/Test/Unit/Etc/ModuleConfigTest.php
+++ b/Test/Unit/Etc/ModuleConfigTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Two\GatewayHyva\Test\Unit\Etc;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Sanity check on etc/module.xml. Catches namespace drift like ABN-362 where the
+ * ABN-layer commit renamed every PHP class but missed the module declaration.
+ */
+class ModuleConfigTest extends TestCase
+{
+    private const MODULE_XML = __DIR__ . '/../../../etc/module.xml';
+
+    public function testModuleXmlParses(): void
+    {
+        $xml = simplexml_load_file(self::MODULE_XML);
+        $this->assertNotFalse($xml, 'etc/module.xml must be valid XML');
+    }
+
+    public function testModuleNameAndSequenceMatchNamespace(): void
+    {
+        $xml = simplexml_load_file(self::MODULE_XML);
+        $module = $xml->module;
+
+        $expectedModule = $this->expectedModuleName();
+        $expectedParent = $this->expectedParentModule();
+
+        $this->assertSame(
+            $expectedModule,
+            (string)$module['name'],
+            'module/@name must match the autoload PSR-4 brand'
+        );
+
+        $sequenced = [];
+        foreach ($module->sequence->module as $dep) {
+            $sequenced[] = (string)$dep['name'];
+        }
+        $this->assertContains(
+            $expectedParent,
+            $sequenced,
+            sprintf('module sequence must depend on %s', $expectedParent)
+        );
+    }
+
+    /**
+     * Read the PSR-4 namespace from composer.json to derive the expected module
+     * name. Two\GatewayHyva → Two_GatewayHyva, ABN\GatewayHyva → ABN_GatewayHyva.
+     */
+    private function expectedModuleName(): string
+    {
+        $composer = json_decode(file_get_contents(__DIR__ . '/../../../composer.json'), true);
+        $namespaces = array_keys($composer['autoload']['psr-4']);
+        $primary = rtrim($namespaces[0], '\\');
+        return str_replace('\\', '_', $primary);
+    }
+
+    private function expectedParentModule(): string
+    {
+        $composer = json_decode(file_get_contents(__DIR__ . '/../../../composer.json'), true);
+        $namespaces = array_keys($composer['autoload']['psr-4']);
+        $primary = rtrim($namespaces[0], '\\');
+        // Two\GatewayHyva → Two_Gateway, ABN\GatewayHyva → ABN_Gateway
+        $parts = explode('\\', $primary);
+        return $parts[0] . '_Gateway';
+    }
+}

--- a/Test/bootstrap.php
+++ b/Test/bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+// Minimal bootstrap for unit tests that don't need Magento DI.
+// Tests requiring Magento framework classes should add stubs under Test/Stubs/
+// and require them here.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+         bootstrap="Test/bootstrap.php"
+         colors="true"
+         verbose="true"
+         defaultTestSuite="Unit">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>Test/Unit/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
## Summary

Round out the local development environment in `magento-hyva-extension` to match the surface available in `magento-plugin` and `magento-abn-plugin`. Closes INF-1072.

## What's in

### Dev environment
- **FRP proxy auto-start** at end of `make install` (mirrors the existing `make run` / `make debug` proxy paths, prints the proxy URL with the rest of the install summary)
- **`flush` target** — clears frontend + adminhtml static content + cache flush, useful when iterating on `.phtml`/CSS/JS without reinstalling
- **`TWO_BRAND` / `TWO_BRAND_VERSION` env vars** passed into the dev container with empty defaults (mechanism only, mirrors `magento-plugin` Makefile). Parent plugin's `dev/configure` reads these.
- **Lang pack composer requires** in `make install` — five Two-supported locales (`nl_NL`, `nb_NO`, `sv_SE`, `fi_FI`, `da_DK`), already on `magento-plugin` main, ported here verbatim. Explicit list rather than brace expansion (Make recipes run via `/bin/sh`, not bash).

### Tests
- **`test` target** — pinned PHPUnit 9.6.34 phar with SHA256 verification, runs in `php:8.1-cli` container (mirrors `magento-abn-plugin` pattern)
- **`phpunit.xml` + `Test/bootstrap.php`** — minimal scaffolding, no Magento stubs (this module's PHP surface is small; stubs added piecemeal as features land)
- **`Test/Unit/Etc/ModuleConfigTest.php`** — derives expected `module/@name` and sequence dep from `composer.json` PSR-4, asserts `etc/module.xml` matches. Catches the same drift class as ABN-362.

### Brand overlay (architectural)
- **`-include Makefile.brand`** at the top of `Makefile`. File is gitignored on `main` and absent here. Consumed only when an `abn-main`-style brand overlay puts a `Makefile.brand` next to it.
- **`LOG_DIR ?= var/log/two`** — `logs:` target uses `$(LOG_DIR)` so brand overlays can override via `LOG_DIR := var/log/abn`.
- **`make help`** prints the active brand as a header line (`Brand: two` here, `Brand: achterafbetalen` if an overlay overrides).
- **AGENTS.md** gains *Branch Model* and *Brand overlay* sections explaining the pattern. The "main + 1 commit" framing is updated to "main + N commits" to reflect the actual state since branch protection on `abn-main` blocks force-push.

The architectural piece sets up Track 4 (separate ABN ticket) where `abn-main` adds its own `Makefile.brand` with ABN-flavor URLs, country, log path, GCS publish target.

## What's out (intentionally)

- `test-e2e` target from `magento-abn-plugin` — this module has no API client logic to E2E-test against; defer until something here actually warrants it
- Bulk port of unit tests for `CheckoutConfig` / `GetQuoteDetails` — heavy mocking against parent plugin classes; better added piecemeal as related features land
- ABN-flavor Makefile bits (achterafbetalen URL defaults, NL country, abn log path, GCS publish, abn git remote tag target) — go to `abn-main`'s `Makefile.brand` in a follow-up ABN ticket

## Adversarial review notes

Three reviewers (simplification, correctness, ergonomics) shredded a v1 of this. Resulting changes:
- Lang packs ported as explicit list, not bash-only brace expansion (Make recipe portability)
- `-include Makefile.brand` placed at top with locking comment (controls `?=` evaluation order)
- `LOG_DIR` variable pattern instead of redefining `logs:` target (avoids "overriding recipe" warning on overlay)
- `Makefile.brand` gitignored on `main` (prevents stale-file footguns when switching branches)
- `$(info ...)` line announces overlay activation when present
- AGENTS.md branch-model accuracy fix (was lying about "main + 1 commit")

## Test plan

- [x] `make test` runs in container and passes (2 tests, 3 assertions)
- [x] `make help` shows new `flush`, `test` targets and `Brand: two` header
- [ ] `make install` prints proxy URL after Xdebug install
- [ ] `make logs` tails `var/log/two/` (default `LOG_DIR`)
- [ ] On a hypothetical `abn-main` checkout with `Makefile.brand` present, `make help` shows `Brand: achterafbetalen` and `make logs` uses `var/log/abn/` (verified once Track 4 lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)