### PR TITLE
ABN-364/feat: Makefile.brand overlay (stacked on ABN-362)

### DIFF
--- a/Makefile.brand
+++ b/Makefile.brand
@@ -1,0 +1,37 @@
+# ==============================================================================
+# Brand overlay — ABN AMRO
+# ==============================================================================
+# This file only exists on `abn-main`. If you see it on `main`, it is stale
+# from a previous checkout — delete it.
+#
+# Loaded via `-include Makefile.brand` at the top of the main Makefile.
+# Uses `:=` so brand defaults win against main's `?=` defaults.
+#
+# Target redefinitions (`archive`, `tag`) emit "overriding recipe for target"
+# warnings under GNU make; that is intentional and documented in AGENTS.md.
+# A future cleanup may extract `ARCHIVE_NAME` / `TAG_PREFIX` variables to make
+# these variable-overrides instead of recipe-overrides.
+#
+# See AGENTS.md → Brand overlay for the design rationale.
+
+BRAND                 := achterafbetalen
+TWO_API_BASE_URL      := https://api.$(TWO_ENV).achterafbetalen.abnamro.nl
+TWO_CHECKOUT_BASE_URL := https://checkout.$(TWO_ENV).achterafbetalen.abnamro.nl
+TWO_STORE_COUNTRY     := NL
+TWO_BRAND             := achterafbetalen
+TWO_BRAND_VERSION     := $(if $(filter staging,$(TWO_ENV)),qa,)
+LOG_DIR               := var/log/abn
+
+.PHONY: publish tag
+
+## Tag the release and push to abn-main-csp (ABN release flow)
+tag:
+	eval $$(bumpver show --environ) && git tag abn-$${CURRENT_VERSION} -f && git push origin abn-$${CURRENT_VERSION} -f && git push origin abn-main-csp -f
+
+## Build the ABN-flavored archive zip under artifacts/<version>/
+archive:
+	eval $$(bumpver show --environ) && mkdir -p artifacts/$${CURRENT_VERSION} && git archive --format zip HEAD > artifacts/$${CURRENT_VERSION}/magento-abn-hyva-extension.zip
+
+## Publish archive to GCS bucket and refresh download index
+publish: archive
+	gsutil cp -r artifacts/* gs://achteraf-betalen/magento-hyva/ && ./scripts/publish-to-bucket.py


### PR DESCRIPTION
## Summary

Adds `Makefile.brand` to abn-main, consumed by `-include Makefile.brand` in the top of main's Makefile (introduced in INF-1072 / [PR #8](https://github.com/two-inc/magento-hyva-extension/pull/8)).

Closes ABN-364.

## Stacked PR — base is doug/abn-362-module-xml-fix

This PR is stacked on top of [PR #7 (ABN-362)](https://github.com/two-inc/magento-hyva-extension/pull/7). When ABN-362 merges, GitHub will auto-rebase this PR's base to `abn-main`.

## Sequencing

This PR is **functionally dependent** on:

1. INF-1072 (PR #8) merging to `main` — provides `-include Makefile.brand` hook
2. abn-main being rebased forward to inherit the hook + lose its current 9-line truncated Makefile in favour of main's full Makefile

Until both happen, `Makefile.brand` sits in the repo loaded but unreferenced. Merging this before the rebase is harmless but the file does nothing.

Recommended merge order:
- ABN-362 (PR #7) → abn-main ✅ first
- INF-1072 (PR #8) → main
- abn-main rebase forward (whoever owns the ABN layer rebase)
- This PR (ABN-364) → abn-main

## What's in

Brand-flavour overrides (all `:=` to win against main's `?=`):

- `TWO_API_BASE_URL` / `TWO_CHECKOUT_BASE_URL` → `achterafbetalen.abnamro.nl`
- `TWO_STORE_COUNTRY` → `NL`
- `TWO_BRAND` / `TWO_BRAND_VERSION` → `achterafbetalen` / `qa` on staging
- `LOG_DIR` → `var/log/abn`
- `BRAND` → `achterafbetalen` (surfaces in `make help` header)

ABN-only targets:

- `tag`: pushes `abn-<version>` tag and `abn-main-csp` branch to `origin` (matches existing abn-main tag flow before truncation)
- `archive`: builds `magento-abn-hyva-extension.zip` under `artifacts/<version>/`
- `publish`: copies to `gs://achteraf-betalen/magento-hyva/` and refreshes the download index via the existing `scripts/publish-to-bucket.py`

## Recipe override warnings

`archive:` and `tag:` are redefined here, since main's recipes have different filenames / push patterns. GNU make will emit "overriding recipe for target" warnings to stderr — that is intentional and noted in `AGENTS.md`. A future cleanup can extract `ARCHIVE_NAME` / `TAG_PREFIX` / `TAG_PUSH_REMOTE` variables to convert these to clean variable overrides; out of scope for this PR.

## Test plan

After full sequencing completes (INF-1072 merged + abn-main rebased + this merged):

- [ ] `make help` on abn-main shows `Brand: achterafbetalen` header
- [ ] `make help` lists `publish` and `tag` targets
- [ ] `make logs` references `var/log/abn/`
- [ ] `make` prints `Loaded Makefile.brand — brand overlay active`
- [ ] AGENTS.md `Two_GatewayHyva` verification grep stays clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)