### PR TITLE
fix: inject BrandRegistryInterface for product/provider name lookups

### DIFF
--- a/ViewModel/CheckoutConfig.php
+++ b/ViewModel/CheckoutConfig.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Two\GatewayHyva\ViewModel;
 
 use Magento\Framework\View\Asset\Repository as AssetRepository;
+use Two\Gateway\Api\BrandRegistryInterface;
 use Two\Gateway\Api\Config\RepositoryInterface as ConfigRepository;
 use Two\Gateway\Service\UrlCookie;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
@@ -24,6 +25,11 @@ class CheckoutConfig implements ArgumentInterface
      * @var ConfigRepository
      */
     private $configRepository;
+
+    /**
+     * @var BrandRegistryInterface
+     */
+    private $brandRegistry;
 
     /**
      * @var Two
@@ -44,6 +50,7 @@ class CheckoutConfig implements ArgumentInterface
      * CheckoutConfig constructor.
      *
      * @param ConfigRepository $configRepository
+     * @param BrandRegistryInterface $brandRegistry
      * @param Adapter $adapter
      * @param Two $two
      * @param AssetRepository $assetRepository
@@ -51,11 +58,13 @@ class CheckoutConfig implements ArgumentInterface
 
     public function __construct(
         ConfigRepository $configRepository,
+        BrandRegistryInterface $brandRegistry,
         Adapter $adapter,
         Two $two,
         AssetRepository $assetRepository,
     ) {
         $this->configRepository = $configRepository;
+        $this->brandRegistry = $brandRegistry;
         $this->adapter = $adapter;
         $this->two = $two;
         $this->assetRepository = $assetRepository;
@@ -161,7 +170,7 @@ class CheckoutConfig implements ArgumentInterface
     {
         $orderIntentApprovedMessage = __(
             "Your invoice purchase with %1 is likely to be accepted subject to additional checks.",
-            $this->configRepository::PRODUCT_NAME,
+            $this->brandRegistry->getProductName(),
         );
         return $orderIntentApprovedMessage;
     }
@@ -170,7 +179,7 @@ class CheckoutConfig implements ArgumentInterface
     {
         $orderIntentDeclinedMessage = __(
             "Your invoice purchase with %1 has been declined.",
-            $this->configRepository::PRODUCT_NAME,
+            $this->brandRegistry->getProductName(),
         );
         return $orderIntentDeclinedMessage;
     }
@@ -180,7 +189,7 @@ class CheckoutConfig implements ArgumentInterface
         $tryAgainLater = __("Please try again later.");
         $generalErrorMessage = __(
             "Something went wrong with your request to %1. %2",
-            $this->configRepository::PRODUCT_NAME,
+            $this->brandRegistry->getProductName(),
             $tryAgainLater,
         );
         return $generalErrorMessage;
@@ -198,7 +207,7 @@ class CheckoutConfig implements ArgumentInterface
     {
         $paymentTerms = __(
             "%1 terms and conditions",
-            $this->configRepository::PROVIDER,
+            $this->brandRegistry->getProvider(),
         );
         $paymentTermsLink =
             $this->configRepository->getCheckoutPageUrl() . "/terms";
@@ -217,7 +226,7 @@ class CheckoutConfig implements ArgumentInterface
     {
         $paymentTerms = __(
             "%1 terms and conditions",
-            $this->configRepository::PROVIDER,
+            $this->brandRegistry->getProvider(),
         );
         $termsNotAcceptedMessage = __(
             "You must accept %1 to place order.",
@@ -233,7 +242,7 @@ class CheckoutConfig implements ArgumentInterface
         );
         $soleTraderErrorMessage = __(
             "Something went wrong with your request to %1. %2",
-            $this->configRepository::PRODUCT_NAME,
+            $this->brandRegistry->getProductName(),
             $soleTraderaccountCouldNotBeVerified,
         );
         return $soleTraderErrorMessage;


### PR DESCRIPTION
## Summary
`CheckoutConfig::getOrderIntentApprovedMessage` and friends still reference `$this->configRepository::PRODUCT_NAME` and `::PROVIDER` as class constants. Those constants were removed from `magento-plugin@staging/Model/Config/Repository.php` (now-current comment reads `// Brand-bound values (PROVIDER, PROVIDER_FULL_NAME, PRODUCT_NAME, ...) — call methods rather than re-introducing constants here`) as part of the brand-overlay 2.0 work in `magento-abn-plugin docs/implementation-plan.md`.

Hyva checkout 500s on any Magento install running `magento-plugin@staging` with this extension:

```
Error: Undefined constant Two\\Gateway\\Model\\Config\\Repository::PRODUCT_NAME
  at /var/www/html/.../hyva/ViewModel/CheckoutConfig.php:164
```

## Fix
Inject `Two\Gateway\Api\BrandRegistryInterface` into `CheckoutConfig` and route the six product-name / provider lookups through it (`getProductName()`, `getProvider()`). The `TwoBrand` implementation in `magento-plugin@staging` returns identical values to what the old constants held.

## Why `main` not `develop`
Per `magento-abn-plugin docs/implementation-plan.md` §1.2, `main` is the new default branch on this repo post brand-overlay 2.0 work. Earlier draft targeted `develop` (#15, closed). `develop` has no commits `main` doesn't.