### PR TITLE
fix(checkout): align company-id label to Company number

### DIFF
--- a/view/frontend/templates/component/payment/method/gateway_method.phtml
+++ b/view/frontend/templates/component/payment/method/gateway_method.phtml
@@ -120,7 +120,7 @@ $quoteDetails = json_encode(
             <!-- Company ID - Single input -->
             <div class="flex flex-col field field-reserved required">
               <label for="company_id" class="font-semibold text-gray-700">
-                <?= $escaper->escapeHtmlAttr(__("Company ID")) ?>
+                <?= $escaper->escapeHtmlAttr(__("Company number")) ?>
               </label>
               <input
                 type="text"


### PR DESCRIPTION
## Summary

Vanilla `magento-plugin` renames the storefront company-id label from "KVK number" to "Company number" (see two-inc/magento-plugin#131). Hyva-checkout template previously used "Company ID" — drift across themes for the same field. Aligning on the vanilla source string so brand-overlay translation CSVs apply consistently in both Hyva and Luma checkouts.

## Test plan

- [ ] Hyva checkout renders "Company number" on UK / SE / NO / DE shops on the vanilla brand
- [ ] Brand-overlay CSV translations (e.g. ABN's `KVK-nummer` on `nl_NL`) still fire under Hyva

🤖 Generated with [Claude Code](https://claude.com/claude-code)