### PR TITLE
test: salvage PHPUnit harness and module-config sanity test from PR #8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ node_modules/
 # AI assistants
 CLAUDE.local.md
 .aider*
+.agent-notes/
+.serena/
+.claude/

--- a/Test/Unit/Etc/ModuleConfigTest.php
+++ b/Test/Unit/Etc/ModuleConfigTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Two\GatewayHyva\Test\Unit\Etc;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Sanity check on etc/module.xml. Catches namespace drift like ABN-362 where the
+ * ABN-layer commit renamed every PHP class but missed the module declaration.
+ */
+class ModuleConfigTest extends TestCase
+{
+    private const MODULE_XML = __DIR__ . '/../../../etc/module.xml';
+
+    public function testModuleXmlParses(): void
+    {
+        $xml = simplexml_load_file(self::MODULE_XML);
+        $this->assertNotFalse($xml, 'etc/module.xml must be valid XML');
+    }
+
+    public function testModuleNameAndSequenceMatchNamespace(): void
+    {
+        $xml = simplexml_load_file(self::MODULE_XML);
+        $module = $xml->module;
+
+        $expectedModule = $this->expectedModuleName();
+        $expectedParent = $this->expectedParentModule();
+
+        $this->assertSame(
+            $expectedModule,
+            (string)$module['name'],
+            'module/@name must match the autoload PSR-4 brand'
+        );
+
+        $sequenced = [];
+        foreach ($module->sequence->module as $dep) {
+            $sequenced[] = (string)$dep['name'];
+        }
+        $this->assertContains(
+            $expectedParent,
+            $sequenced,
+            sprintf('module sequence must depend on %s', $expectedParent)
+        );
+    }
+
+    /**
+     * Read the PSR-4 namespace from composer.json to derive the expected module
+     * name. Two\GatewayHyva → Two_GatewayHyva, ABN\GatewayHyva → ABN_GatewayHyva.
+     */
+    private function expectedModuleName(): string
+    {
+        $composer = json_decode(file_get_contents(__DIR__ . '/../../../composer.json'), true);
+        $namespaces = array_keys($composer['autoload']['psr-4']);
+        $primary = rtrim($namespaces[0], '\\');
+        return str_replace('\\', '_', $primary);
+    }
+
+    private function expectedParentModule(): string
+    {
+        $composer = json_decode(file_get_contents(__DIR__ . '/../../../composer.json'), true);
+        $namespaces = array_keys($composer['autoload']['psr-4']);
+        $primary = rtrim($namespaces[0], '\\');
+        // Two\GatewayHyva → Two_Gateway, ABN\GatewayHyva → ABN_Gateway
+        $parts = explode('\\', $primary);
+        return $parts[0] . '_Gateway';
+    }
+}

--- a/Test/bootstrap.php
+++ b/Test/bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+// Minimal bootstrap for unit tests that don't need Magento DI.
+// Tests requiring Magento framework classes should add stubs under Test/Stubs/
+// and require them here.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="Test/bootstrap.php"
+         colors="true"
+         defaultTestSuite="Unit">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>Test/Unit/</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">.</directory>
+        </include>
+        <exclude>
+            <directory>Test</directory>
+            <directory>vendor</directory>
+        </exclude>
+    </source>
+</phpunit>


### PR DESCRIPTION
## Summary

Salvages the image-independent test infrastructure from the abandoned dev-tooling work on `feat/dev-tools` (PR #8, INF-1072). The Hyva-bundling dev-image effort itself was dropped because of commercial licensing, but the unit-test harness has no dependency on that and is worth keeping on `staging`.

What's included:

- **`phpunit.xml`** — PHPUnit 10.5 schema (aligned with the recently-bumped vanilla `magento-plugin` config). Unit suite under `Test/Unit/`. `<source>` block scopes coverage to module sources, excluding `Test` and `vendor`.
- **`Test/bootstrap.php`** — minimal autoload-only bootstrap. Tests requiring Magento framework classes can drop stubs into `Test/Stubs/` and require them from here.
- **`Test/Unit/Etc/ModuleConfigTest.php`** — sanity check on `etc/module.xml`. Catches namespace-drift bugs of the ABN-362 flavour (where the ABN-fork commit renamed every PHP class but missed the module declaration). Derives the expected module name from `composer.json`'s PSR-4 root, so it works on Two-branded and overlay-branded forks alike.
- **`.gitignore`** — adds `.agent-notes/`, `.serena/`, `.claude/` (AI-assistant working directories).

Intentionally NOT carried forward from PR #8:

- The Makefile changes (FRP proxy, language packs, brand overlay, flush target). Dev-image effort dropped because of Hyva licensing — these targets are now dead.
- The `Makefile.brand` `.gitignore` entry and the AGENTS.md "Branch Model" / "Brand overlay" sections. ABN excision from this repository is pending and that overlay model is about to be removed.

PR #8 can be closed after this lands.

## Test plan

- [ ] CI runs PHPUnit suite and ModuleConfigTest passes (module name + parent module sequence match composer PSR-4 root)
- [ ] No regression in existing checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)