### PR TITLE
chip: swap selected-chip palette to Two-brand blue to match .mode_item

### DIFF
--- a/view/frontend/web/css/custom.css
+++ b/view/frontend/web/css/custom.css
@@ -77,6 +77,14 @@ summary::marker {
   margin-top: 4px;
 }
 
+/*
+ * Chip colour palette mirrors `.mode_item` on the Luma checkout
+ * (Registered Organisation / Sole Trader toggle): solid Two-brand blue
+ * (#3043d1) for the selected state, white fill with blue text for
+ * unselected. Brand overlays that ship a different palette (e.g. ABN's
+ * teal/white pairing) override these rules from their own custom.css
+ * which loads after this one.
+ */
 .two-term-chip {
   display: flex;
   flex-direction: column;
@@ -85,14 +93,15 @@ summary::marker {
   border: 2px solid #e0e0e0;
   border-radius: 8px;
   background: #fff;
+  color: #3043d1;
   cursor: pointer;
-  transition: border-color 0.15s ease;
+  transition: border-color 0.15s ease, background-color 0.15s ease, color 0.15s ease;
   min-width: 80px;
   font-family: inherit;
   position: relative;
 }
 
-.two-term-chip:hover { border-color: #699797; }
+.two-term-chip:hover { border-color: #3043d1; }
 .two-term-chip:focus { outline: none; }
 .two-term-chip[disabled] { cursor: wait; opacity: 0.7; }
 
@@ -100,9 +109,9 @@ summary::marker {
 .two-term-chip--selected:hover,
 .two-term-chip--selected:focus,
 .two-term-chip--selected:active {
-  border-color: #699797;
-  background: #fff;
-  color: inherit;
+  border-color: #3043d1;
+  background: #3043d1;
+  color: #fff;
 }
 
 .two-term-chip__days {
@@ -116,7 +125,7 @@ summary::marker {
 
 .two-term-chip--selected .two-term-chip__days::before {
   content: '\2713';
-  color: #699797;
+  color: #fff;
   font-size: 14px;
   font-weight: 700;
 }
@@ -130,7 +139,7 @@ summary::marker {
 .two-term-chip__loading {
   display: inline-block;
   letter-spacing: 2px;
-  color: #999;
+  color: currentColor;
   font-size: 12px;
   line-height: 1.3;
   font-weight: 700;
@@ -153,11 +162,13 @@ summary::marker {
   flex-direction: row;
   align-items: center;
   gap: 8px;
-  border-color: #699797;
+  border-color: #3043d1;
+  background: #3043d1;
+  color: #fff;
   cursor: default;
   font-size: 14px;
   font-weight: 500;
 }
 
-.two-term-chip--single:hover { border-color: #699797; }
+.two-term-chip--single:hover { border-color: #3043d1; }
 .two-term-chip--single .two-term-chip__surcharge { font-size: 14px; }


### PR DESCRIPTION
## Summary

Mirrors [magento-plugin#doug/chip-vanilla-blue](https://github.com/two-inc/magento-plugin/pulls?q=is%3Apr+head%3Adoug%2Fchip-vanilla-blue) on the Hyvä side. The term-chip widget should track the same colour family as the `.mode_item` toggle (Registered Organisation / Sole Trader) elsewhere on the Luma checkout: white fill with blue text when unselected, solid Two-brand blue (`#3043d1`) with white text when selected.

- **unselected chip**: white fill, blue text, light-gray border
- **selected chip**: solid blue fill, white text, blue border
- **selected tick** (`::before`): white (was teal `#699797`)
- **single-term variant**: solid blue fill, white text
- **loading dots**: `currentColor` (was `#999`)

## Brand overlays

ABN_GatewayHyva ships a brand-specific overlay pinning the old teal palette — see [magento-abn-plugin#doug/chip-abn-overlay-teal](https://github.com/two-inc/magento-abn-plugin/pulls?q=is%3Apr+head%3Adoug%2Fchip-abn-overlay-teal). Land that PR before/alongside this one.

Companion: [magento-plugin#doug/chip-vanilla-blue](https://github.com/two-inc/magento-plugin/pulls?q=is%3Apr+head%3Adoug%2Fchip-vanilla-blue).

## Test plan

- [ ] On `magento.staging.two.inc/hyva/checkout/`, select `two_payment` → selected chip is solid blue with white text + white tick.
- [ ] Hover unselected chip → blue border.
- [ ] Click between 30/60/90 — selection swaps; loading dots remain legible.
- [ ] No regression on `magento.staging.achterafbetalen.co/hyva/checkout/` (ABN brand) once both the gitSync re-enable (platform-tools#653) and the ABN overlay PR ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)