### PR TITLE
ABN-398/refactor: prefix Hyva CSP-JS validatePaymentForm with two

### DIFF
--- a/view/frontend/templates/component/payment/method/gateway_method-csp-js.phtml
+++ b/view/frontend/templates/component/payment/method/gateway_method-csp-js.phtml
@@ -68,7 +68,7 @@ $quoteDetails = json_encode($quoteDetails);
                '';
     };
 
-    function validatePaymentForm(form, wire) {
+    function twoValidatePaymentForm(form, wire) {
         let timeout = null;
         let dirty = false;
 
@@ -679,7 +679,7 @@ $quoteDetails = json_encode($quoteDetails);
     function twoGatewayHyvaPaymentFormWithValidation() {
         return {
             ...twoGatewayHyvaPaymentMethodBase(),
-            ...validatePaymentForm(this.$el, this.$wire)
+            ...twoValidatePaymentForm(this.$el, this.$wire)
         };
     }
 


### PR DESCRIPTION
## Summary

Rename `function validatePaymentForm` → `twoValidatePaymentForm` in the Hyva CSP-JS template (`view/frontend/templates/component/payment/method/gateway_method-csp-js.phtml`).

Hygiene for future brand overlays — the ABN overlay already prefixes its copy as `abnValidatePaymentForm` ([magento-abn-plugin PR #108](https://github.com/two-inc/magento-abn-plugin/pull/108)). Pre-rename the global symbol in vanilla so overlays can shadow without colliding.

Linear: [ABN-398](https://linear.app/tillit/issue/ABN-398) — PR B of the cleanup series.

## Changes

- Function declaration at line 71
- Single callsite at line 682

Exactly 2 hits, both inside the same template. No external JS calls this as a global (verified across `magento-hyva-extension` and `magento-plugin`).

## Test plan

- [ ] Vanilla checkout reaches payment step; DevTools shows `typeof window.twoValidatePaymentForm === 'function'` and `window.validatePaymentForm === undefined`
- [ ] ABN overlay checkout still functions — `abnValidatePaymentForm` unaffected
- [ ] Admin Two plugin tab still renders on both sites