### PR TITLE
ABN-398: locale-aware chip currency + chip-flicker fix + 20px margin

### DIFF
--- a/Magewire/Checkout/Payment/GatewayMethod.php
+++ b/Magewire/Checkout/Payment/GatewayMethod.php
@@ -12,6 +12,7 @@ use Magento\Checkout\Model\Session;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Locale\ResolverInterface as LocaleResolver;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Api\CartTotalRepositoryInterface;
 use Magewirephp\Magewire\Component;
@@ -46,6 +47,17 @@ class GatewayMethod extends Component
 
     public string $currencyCode = '';
 
+    /**
+     * Magento store-view locale (e.g. `nl_NL`, `en_GB`), normalised
+     * to BCP-47 (`nl-NL`, `en-GB`) and passed to the chip's
+     * Intl.NumberFormat so the surcharge currency renders in the
+     * same format Magento uses for the order-summary line items
+     * — avoiding the buyer-visible inconsistency where the chip
+     * shows `€16.03` (browser default) while the summary shows
+     * `€ 16,03` (Magento Dutch format).
+     */
+    public string $currencyLocale = '';
+
     public bool $showChip = false;
 
     protected $loader = true;
@@ -72,6 +84,7 @@ class GatewayMethod extends Component
         private ConfigRepository $configRepository,
         private SurchargeCalculator $surchargeCalculator,
         private LogRepository $logRepository,
+        private LocaleResolver $localeResolver,
         private string $methodCode = 'two_payment',
     ) {}
 
@@ -183,6 +196,9 @@ class GatewayMethod extends Component
             $this->availableTerms = $terms;
             $this->surchargeDescription = (string) $this->configRepository->getSurchargeLineDescription($storeId);
             $this->currencyCode = (string) ($quote->getQuoteCurrencyCode() ?: $quote->getStore()->getBaseCurrencyCode());
+            // Magento stores locale as `nl_NL`; Intl.NumberFormat expects
+            // BCP-47 with hyphens. Translate.
+            $this->currencyLocale = (string) str_replace('_', '-', (string) $this->localeResolver->getLocale());
 
             $sessionTerm = (int) $this->checkoutSession->getTwoSelectedTerm();
             $defaultTerm = (int) $this->configRepository->getDefaultPaymentTerm($storeId);
@@ -196,6 +212,7 @@ class GatewayMethod extends Component
             $this->availableTerms = [];
             $this->termSurcharges = [];
             $this->currencyCode = '';
+            $this->currencyLocale = '';
         }
     }
 

--- a/view/frontend/templates/component/payment/method/gateway_method-csp-js.phtml
+++ b/view/frontend/templates/component/payment/method/gateway_method-csp-js.phtml
@@ -747,14 +747,31 @@ $quoteDetails = json_encode($quoteDetails);
                 const amount = parseFloat(raw);
                 if (!isFinite(amount) || amount <= 0) return '';
                 const currency = this.$wire.currencyCode || 'EUR';
+                // Use the Magento store-view locale piped from PHP
+                // (`nl-NL`, `en-GB`, ...) so the chip's currency format
+                // matches the order summary. Browser default would
+                // produce `€16.03` while Magento formats `€ 16,03`.
+                const locale = this.$wire.currencyLocale || undefined;
                 try {
-                    return new Intl.NumberFormat(undefined, {
+                    return new Intl.NumberFormat(locale, {
                         style: 'currency',
                         currency: currency
                     }).format(amount);
                 } catch (e) {
                     return amount.toFixed(2);
                 }
+            },
+
+            // CSP-friendly Alpine refuses boolean operators in attribute
+            // expressions, so the chip template can't bind to
+            // `x-if="!isLoading && surchargeText"` directly. Without
+            // mutual exclusion the loading-dots span and the surcharge
+            // span both render during a Magewire selectTerm round-trip,
+            // adding a row to the chip and stretching it vertically
+            // until the response lands. Exposed as a getter so the
+            // template can bind via bare property access.
+            get surchargeTextWhenNotLoading() {
+                return this.isLoading ? '' : this.surchargeText;
             },
 
             async select() {

--- a/view/frontend/templates/component/payment/method/gateway_method.phtml
+++ b/view/frontend/templates/component/payment/method/gateway_method.phtml
@@ -66,8 +66,8 @@ $showSingleTerm = $magewire->showChip && count($magewire->availableTerms) === 1;
                             <template x-if="isLoading">
                                 <span class="two-term-chip__loading" aria-hidden="true"><span>.</span><span>.</span><span>.</span></span>
                             </template>
-                            <template x-if="surchargeText">
-                                <span class="two-term-chip__surcharge" x-text="surchargeText"></span>
+                            <template x-if="surchargeTextWhenNotLoading">
+                                <span class="two-term-chip__surcharge" x-text="surchargeTextWhenNotLoading"></span>
                             </template>
                         </button>
                     <?php endforeach ?>

--- a/view/frontend/web/css/custom.css
+++ b/view/frontend/web/css/custom.css
@@ -172,3 +172,8 @@ summary::marker {
 
 .two-term-chip--single:hover { border-color: #3043d1; }
 .two-term-chip--single .two-term-chip__surcharge { font-size: 14px; }
+
+/* QA polish: more breathing room between the "Selected payment terms"
+   caption and the chip strip. Tailwind utility `mb-1` on the label is
+   too tight visually. */
+.two-term-chips > label.label { margin-bottom: 20px; }


### PR DESCRIPTION
Three QA polish fixes for the term-chip subsystem. See commit body. Paired with magento-abn-plugin PR forwarding the new LocaleResolver dep through ABN's Magewire subclass.