### PR TITLE
ABN-401/fix: selectTerm invalid-term rejection returns 400, not 500

### DIFF
--- a/Magewire/Checkout/Payment/GatewayMethod.php
+++ b/Magewire/Checkout/Payment/GatewayMethod.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 namespace Two\GatewayHyva\Magewire\Checkout\Payment;
 
 use Magento\Checkout\Model\Session;
-use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Locale\ResolverInterface as LocaleResolver;
 use Magento\Quote\Api\CartRepositoryInterface;
@@ -141,7 +141,12 @@ class GatewayMethod extends Component
         $allowedTerms = array_map('intval', $this->configRepository->getAllBuyerTerms($storeId));
 
         if (! in_array($days, $allowedTerms, true)) {
-            throw new InputException(__('Selected payment term is not available.'));
+            // HttpException(400) — Magewire's Livewire controller catches
+            // generic exceptions and maps `code === 0` to HTTP 500, which is
+            // wrong for client-supplied invalid input. HttpException is
+            // detected by `instanceof` and yields its declared status code,
+            // so a 400 reaches the buyer unchanged.
+            throw new HttpException(400, (string) __('Selected payment term is not available.'));
         }
 
         $previousTerm = (int) $this->checkoutSession->getTwoSelectedTerm();


### PR DESCRIPTION
## Context

ABN-401 row B9 found that requesting a payment-term value not in the configured set (replay \`selectTerm(15)\` when terms are \`[30, 90]\`) returned HTTP 500 with the user-facing message \"Selected payment term is not available.\" The message itself is correct — the status code is wrong because Magewire's Livewire controller maps exceptions with code 0 to HTTP 500, and \`InputException\` carries code 0.

## Changes

- Replaced \`throw new InputException(...)\` with \`throw new HttpException(400, ...)\` in \`Magewire/Checkout/Payment/GatewayMethod::selectTerm()\`.
- Magewire's \`throwException()\` detects \`HttpException\` via instanceof and yields its declared status code, so the buyer-visible message is preserved while the status code becomes 400.

## Scope / Non-goals

- No change to validation logic, message text, or any other branch of \`selectTerm()\`.

## Validation

- Replay endpoint in DevTools: \`selectTerm(15)\` returns 400 (was 500). Message unchanged.
- Valid \`selectTerm(30)\` / \`selectTerm(90)\` continue to round-trip 200.

## Ticket

- https://linear.app/tillit/issue/ABN-401
- https://linear.app/tillit/issue/ABN-405