### PR TITLE
ABN-405/fix: dispatch flash message instead of throwing on invalid term

### DIFF
--- a/Magewire/Checkout/Payment/GatewayMethod.php
+++ b/Magewire/Checkout/Payment/GatewayMethod.php
@@ -10,7 +10,6 @@ namespace Two\GatewayHyva\Magewire\Checkout\Payment;
 
 use Magento\Checkout\Model\Session;
 use Magento\Framework\Exception\LocalizedException;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Locale\ResolverInterface as LocaleResolver;
 use Magento\Quote\Api\CartRepositoryInterface;
@@ -141,12 +140,14 @@ class GatewayMethod extends Component
         $allowedTerms = array_map('intval', $this->configRepository->getAllBuyerTerms($storeId));
 
         if (! in_array($days, $allowedTerms, true)) {
-            // HttpException(400) — Magewire's Livewire controller catches
-            // generic exceptions and maps `code === 0` to HTTP 500, which is
-            // wrong for client-supplied invalid input. HttpException is
-            // detected by `instanceof` and yields its declared status code,
-            // so a 400 reaches the buyer unchanged.
-            throw new HttpException(400, (string) __('Selected payment term is not available.'));
+            // Magewire's ComponentManager::processUpdates re-wraps every
+            // thrown exception as a generic LocalizedException, which the
+            // Livewire controller's outer catch can no longer recognise as
+            // 4xx — the response is always 500. Dispatch a flash message
+            // and return: HTTP stays 200, the buyer sees the validation
+            // text via the messenger, and no spurious 500 hits the logs.
+            $this->dispatchErrorMessage(__('Selected payment term is not available.'));
+            return;
         }
 
         $previousTerm = (int) $this->checkoutSession->getTwoSelectedTerm();


### PR DESCRIPTION
## Context

Follow-up to #25. That PR tried `HttpException(400)` to coax Magewire into returning 4xx but didn't change the 500 outcome.

Root cause traced through the deployed vendor: `Magewirephp\Magewire\Model\ComponentManager::processUpdates` at line 89 catches **every** exception that escapes a callMethod handler and rethrows it as a generic `LocalizedException`, stripping the original type. By the time the exception reaches the Livewire controller's outer catch, `instanceof HttpException` is false, `$exception->getCode()` returns 0, and the controller maps 0 to HTTP 500.

Throwing-anything from a Magewire action method is therefore equivalent to throwing-500-with-message. There is no way to coax a 4xx status code out of the exception path.

## Changes

In `Magewire/Checkout/Payment/GatewayMethod::selectTerm()`:

- Replaced \`throw new HttpException(400, …)\` with \`\$this->dispatchErrorMessage(__('Selected payment term is not available.'))\` + early \`return\`.
- HTTP response stays 200.
- Buyer sees the validation message via Hyvä's flash messenger.
- No spurious 500 in system.log.

## Scope / Non-goals

- Same line of code, same user-facing message text.
- No other branches of \`selectTerm()\` touched.

## Validation

- DevTools network panel: \`selectTerm(15)\` → 200 OK, response body has flash-message effect.
- DevTools UI: error message appears in the Hyvä flash area.
- Valid \`selectTerm(30)\` / \`selectTerm(90)\` continue to round-trip 200 with chip update.

## Ticket

- https://linear.app/tillit/issue/ABN-401
- https://linear.app/tillit/issue/ABN-405