### PR TITLE
ABN-426/fix: docblock parse error in BrandedHyvaViewModelInterface

### DIFF
--- a/ViewModel/BrandedHyvaViewModelInterface.php
+++ b/ViewModel/BrandedHyvaViewModelInterface.php
@@ -29,7 +29,8 @@ interface BrandedHyvaViewModelInterface extends ArgumentInterface
     public function getFormId(): string;
 
     /**
-     * Magento payment-method code (matches etc/config.xml payment/*/code).
+     * Magento payment-method code (matches payment/<code>/code in
+     * etc/config.xml).
      */
     public function getMethodCode(): string;
 


### PR DESCRIPTION
## Context

Hotfix for PR-H1 (#27): docblock on \`getMethodCode()\` contained the substring \`payment/*/code\` which PHP parses as closing the comment (\`*/\`) followed by bare code (\`code).\`). Result: \`ParseError: syntax error, unexpected identifier 'code', expecting 'function' or 'const'\` → Hyva checkout 500 on both brands.

## Changes

Reworded docblock to use \`payment/<code>/code\` placeholder; avoids the \`*/\` token sequence.

## Validation

- Caught immediately on Hyva checkout smoke after deploy.
- Exception log on Two pod has the full stack trace.

## Ticket

- Parent: [ABN-426](https://linear.app/tillit/issue/ABN-426)

🤖 Generated with [Claude Code](https://claude.com/claude-code)