### PR TITLE
ABN-426/fix: CSP-safe !showManual getter restores Company Number field

### DIFF
--- a/view/frontend/templates/component/payment/method/gateway_method-csp-js.phtml
+++ b/view/frontend/templates/component/payment/method/gateway_method-csp-js.phtml
@@ -314,6 +314,15 @@ $quoteDetails = json_encode($quoteDetails);
                 return this.search.length < 3;
             },
 
+            // CSP-friendly Alpine forbids the `!` operator in attribute
+            // expressions. Templates using `x-show="!showManual"` resolve
+            // this magic getter (bare identifier `!showManual`) instead
+            // of evaluating the negation inline. Mirrors the pattern in
+            // magento-abn-plugin/hyva/.../gateway_method-csp-js.phtml.
+            ['!showManual']() {
+                return !this.showManual;
+            },
+
             // Manual / search mode toggle handlers
             <?= $gwBase ?>OnSearchModeClick() {
                 this.showManual = false;


### PR DESCRIPTION
## Context

Bug shipped in PR-H0a — caught by Doug while testing ABN-401 on both Hyva storefronts post-deploy. Both `Company Number*` / `KvK-nummer*` labels render with no input below them.

## Root cause

Hyva's CSP-friendly Alpine build forbids the `!` operator in attribute expressions. The toggle template uses `x-show="!showManual"` on the search-mode Company Number input. ABN's original Alpine factory carries a magic getter literally named `!showManual` (bracket-notation property key) that returns the negation — `x-show="!showManual"` then resolves as a bare identifier lookup rather than an expression evaluation.

PR-H0a backported the dual-input template + toggle state + handlers but missed the `!showManual` getter. Both inputs (search and manual) end up `display:none`:
- `x-show="!showManual"` — CSP build can't evaluate `!`, treats falsy → hidden
- `x-show="showManual"` — bare identifier OK, evaluates `false` → hidden

## Changes

Added the `['!showManual']()` getter to `<?= $gwBase ?>PaymentMethodBase` factory in `gateway_method-csp-js.phtml`.

## Validation

Needs visual recheck on both `magento.staging.two.inc/hyva/checkout/` and `magento.staging.achterafbetalen.co/hyva/checkout/` — Company Number input should appear below its label by default; toggling to manual mode swaps to the manual-mode input.

## Ticket

- Parent: [ABN-426](https://linear.app/tillit/issue/ABN-426)
- Caught during [ABN-401](https://linear.app/tillit/issue/ABN-401) sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)