### PR TITLE
ABN-431/fix: wire:ignore on Hyva payment form preserves user input

### DIFF
--- a/view/frontend/templates/component/payment/method/gateway_method.phtml
+++ b/view/frontend/templates/component/payment/method/gateway_method.phtml
@@ -99,6 +99,27 @@ $showSingleTerm = $magewire->showChip && count($magewire->availableTerms) === 1;
             <?php endif ?>
         </div>
     <?php endif ?>
+    <?php
+    /*
+     * wire:ignore opts the payment-method form subtree out of Magewire's
+     * diff-merge cycle. Without it, Magewire's response to chip-click
+     * (selectTerm) re-renders the form HTML; user-typed values in
+     * company_id / company_name / invoice_emails / project / department /
+     * orderNote / poNumber are lost because none of these inputs are
+     * wire:model-bound (Alpine-managed or plain HTML, populated via
+     * autocomplete or direct user typing). wire:ignore preserves the DOM
+     * subtree across re-renders, so typed values survive.
+     *
+     * No wire:model inputs live inside this form, so opting out of
+     * diff-merge has no functional downside. Order placement reads form
+     * values via document.querySelector at place-time, not via Magewire
+     * state.
+     *
+     * Mitigates ABN-431 (chip-switch wipes payment-form fields). Also
+     * reduces Magewire DOM churn on the form, contributing to lower
+     * session-lock pressure (ABN-432).
+     */
+    ?>
     <form
         x-data="<?= $gwBase ?>PaymentFormWithValidation"
         id="<?= $brandedViewModel->getFormId() ?>"
@@ -107,6 +128,7 @@ $showSingleTerm = $magewire->showChip && count($magewire->availableTerms) === 1;
             ENT_QUOTES,
             "UTF-8",
         ) ?>"
+        wire:ignore
         @keydown.window.prevent.enter
         class="">
         <fieldset class="space-y-4">


### PR DESCRIPTION
## Context

Bug ([ABN-431](https://linear.app/tillit/issue/ABN-431)): clicking a term chip wipes user-typed `company_id` (and other plugin form fields) on Hyva checkout for both Two and ABN brands. Confirmed during ABN-401 sweep on 2026-05-28.

Side-effect of ABN-426 PR-H0a (dual-input manual/search toggle backport into Two). Also affects ABN now that PR-H2 has ABN serving Two's templates.

## Root cause

Chip-click fires the Magewire `selectTerm` action. Server returns updated state. Magewire diff-merges the gateway form's HTML. Inputs in the form (`company_id`, `company_name`, `invoice_emails`, `project`, `department`, `orderNote`, `poNumber`) are NOT `wire:model`-bound — they're Alpine-managed or populated via JS autocomplete. So Magewire's re-issued HTML has no `value="..."` on those inputs, and user-typed values get wiped on every chip switch.

## Fix

Add `wire:ignore` on the `<form>` element in `gateway_method.phtml`. Magewire's diff-merge skips `wire:ignore`d subtrees, preserving the user's typed DOM state across re-renders.

## Why safe

- No `wire:model` inputs live inside this form (all Alpine state + `document.querySelector` at place-time).
- Order placement reads form values via `querySelector`, not Magewire state — `wire:ignore` doesn't block that.
- Chip elements live ABOVE the form (the `<div class="two-term-chips">` wrapper), so chips are NOT inside the ignored subtree — they continue to re-render normally.
- T&C checkbox lives inside our `PaymentTermsComponent` which IS inside the form — also Alpine-managed (`:checked` / `@change`), so the ignore preserves its state correctly.

## Side benefit

Reduces Magewire DOM churn on the payment form, contributing to lower session-lock pressure ([ABN-432](https://linear.app/tillit/issue/ABN-432) — Cm_RedisSession max_concurrency contention seen on chip-switch).

## Scope / Non-goals

- This fixes the **gateway-form** portion of ABN-431. The reported Free-Shipping radio de-selection and T&C-list reset are in Hyva framework components (`shipping/method-list`, `terms-conditions/list`) — not in our plugin's templates, and not reachable from `wire:ignore` here. Those need separate Hyva-framework investigation.
- Holding on the broader navigation-task scoping (originally proposed as a separate commit) — on closer reading the plugin only registers ONE navigation task and it already fires only on order.place / step-transitions, not on chip-switch. No further reduction available there.

## Validation

- Needs visual recheck on both `magento.staging.two.inc/hyva/checkout/` and `magento.staging.achterafbetalen.co/hyva/checkout/`:
  - Populate company via autocomplete.
  - Switch chips — confirm `company_id` and other typed fields retain their values.
  - Place order — confirm order completes successfully (payment data still posts via querySelector at place-time).
- After Priyanka greenlight, observe whether redis session-lock contention pressure dropped on chip interactions.

## Ticket

- [ABN-431](https://linear.app/tillit/issue/ABN-431)
- Related: [ABN-432](https://linear.app/tillit/issue/ABN-432) (Cm_RedisSession knob, chart + platform-tools PRs awaiting Bharat merge)
- Parent: [ABN-426](https://linear.app/tillit/issue/ABN-426)

🤖 Generated with [Claude Code](https://claude.com/claude-code)