### PR TITLE
ABN-422/428/429: Hyva company-search UX + brand-overridable T&C + decoupled chip visibility

### DIFF
--- a/Magewire/Checkout/Payment/GatewayMethod.php
+++ b/Magewire/Checkout/Payment/GatewayMethod.php
@@ -213,7 +213,9 @@ class GatewayMethod extends Component
             // Chips visibility is driven by available payment terms alone.
             // Surcharge type only gates per-chip surcharge value display —
             // term selection is a buyer choice independent of fee sharing.
-            $this->showChip = count($terms) > 0;
+            // Single-term configs render nothing — with one option there
+            // is nothing for the buyer to select.
+            $this->showChip = count($terms) > 1;
             $this->termSurcharges = ($this->showChip && $type !== SurchargeType::NONE)
                 ? $this->computeAllTermSurcharges($quote, $terms)
                 : [];

--- a/Magewire/Checkout/Payment/GatewayMethod.php
+++ b/Magewire/Checkout/Payment/GatewayMethod.php
@@ -210,8 +210,13 @@ class GatewayMethod extends Component
             $defaultTerm = (int) $this->configRepository->getDefaultPaymentTerm($storeId);
             $this->selectedTerm = $sessionTerm > 0 ? $sessionTerm : $defaultTerm;
 
-            $this->showChip = $type !== SurchargeType::NONE && count($terms) > 0;
-            $this->termSurcharges = $this->showChip ? $this->computeAllTermSurcharges($quote, $terms) : [];
+            // Chips visibility is driven by available payment terms alone.
+            // Surcharge type only gates per-chip surcharge value display —
+            // term selection is a buyer choice independent of fee sharing.
+            $this->showChip = count($terms) > 0;
+            $this->termSurcharges = ($this->showChip && $type !== SurchargeType::NONE)
+                ? $this->computeAllTermSurcharges($quote, $terms)
+                : [];
         } catch (\Exception $e) {
             $this->logRepository->addErrorLog('Hyva chip: hydrate failed', $e->getMessage());
             $this->showChip = false;

--- a/ViewModel/BrandedHyvaViewModelInterface.php
+++ b/ViewModel/BrandedHyvaViewModelInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Two\GatewayHyva\ViewModel;
 
+use Magento\Framework\Phrase;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
 
 /**
@@ -40,4 +41,21 @@ interface BrandedHyvaViewModelInterface extends ArgumentInterface
      * in view/frontend/layout/hyva_checkout_components.xml.
      */
     public function getMagewireBlockName(): string;
+
+    /**
+     * Rendered payment-terms acceptance message shown beside the T&C
+     * checkbox in the Hyva checkout. The return may contain HTML (e.g.
+     * an anchor wrapping the terms link). Brand overlays own the full
+     * sentence so the structure can differ across brands (some brands
+     * may omit the link, change wording, or render brand-specific
+     * regulatory language).
+     *
+     * @param string $termsLink Absolute URL to the brand's terms page,
+     *     supplied by the caller so the interface stays free of
+     *     ConfigRepository dependencies.
+     * @param string $brandTermsName Human-readable phrase used as the
+     *     anchor text in brands that render a link (e.g. "Two terms
+     *     and conditions").
+     */
+    public function getPaymentTermsMessage(string $termsLink, string $brandTermsName): Phrase;
 }

--- a/ViewModel/CheckoutConfig.php
+++ b/ViewModel/CheckoutConfig.php
@@ -52,6 +52,11 @@ class CheckoutConfig implements ArgumentInterface
      */
     private $checkoutSession;
 
+    /**
+     * @var BrandedHyvaViewModelInterface
+     */
+    private $brandedViewModel;
+
     public function __construct(
         ConfigRepository $configRepository,
         BrandRegistryInterface $brandRegistry,
@@ -59,6 +64,7 @@ class CheckoutConfig implements ArgumentInterface
         Two $two,
         AssetRepository $assetRepository,
         CheckoutSession $checkoutSession,
+        BrandedHyvaViewModelInterface $brandedViewModel,
     ) {
         $this->configRepository = $configRepository;
         $this->brandRegistry = $brandRegistry;
@@ -66,6 +72,7 @@ class CheckoutConfig implements ArgumentInterface
         $this->two = $two;
         $this->assetRepository = $assetRepository;
         $this->checkoutSession = $checkoutSession;
+        $this->brandedViewModel = $brandedViewModel;
     }
 
     /**
@@ -237,15 +244,10 @@ class CheckoutConfig implements ArgumentInterface
         );
         $paymentTermsLink =
             $this->configRepository->getCheckoutPageUrl() . "/terms";
-        $paymentTermsMessage = __(
-            "By checking this box, I confirm that I have read and agree to %1.",
-            sprintf(
-                '<a class="text-blue-600" href="%s" target="_blank">%s</a>',
-                $paymentTermsLink,
-                $paymentTerms,
-            ),
+        return $this->brandedViewModel->getPaymentTermsMessage(
+            $paymentTermsLink,
+            (string) $paymentTerms,
         );
-        return $paymentTermsMessage;
     }
 
     public function getTermsNotAcceptedMessage()

--- a/ViewModel/TwoBrandedHyvaViewModel.php
+++ b/ViewModel/TwoBrandedHyvaViewModel.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Two\GatewayHyva\ViewModel;
 
+use Magento\Framework\Phrase;
+
 final class TwoBrandedHyvaViewModel implements BrandedHyvaViewModelInterface
 {
     public function getAlpineFnPrefix(): string
@@ -24,5 +26,17 @@ final class TwoBrandedHyvaViewModel implements BrandedHyvaViewModelInterface
     public function getMagewireBlockName(): string
     {
         return 'checkout.payment.method.two-payment-method';
+    }
+
+    public function getPaymentTermsMessage(string $termsLink, string $brandTermsName): Phrase
+    {
+        return __(
+            "By checking this box, I confirm that I have read and agree to %1.",
+            sprintf(
+                '<a class="text-blue-600" href="%s" target="_blank">%s</a>',
+                $termsLink,
+                $brandTermsName,
+            ),
+        );
     }
 }

--- a/view/frontend/templates/component/payment/method/gateway_method-csp-js.phtml
+++ b/view/frontend/templates/component/payment/method/gateway_method-csp-js.phtml
@@ -450,35 +450,38 @@ $quoteDetails = json_encode($quoteDetails);
                     return;
                 }
 
-                this.searchTimeout = setTimeout(async () => {
-                    window.dispatchEvent(new Event('magewire:loader:start'));
-                    try {
-                        const queryParams = new URLSearchParams({
-                            country: this.countryCode.toUpperCase(),
-                            limit: this.companySearchLimit,
-                            offset: 0,
-                            q: unescape(this.search),
-                        });
+                // Inline search — no global magewire:loader dispatch.
+                // The dropdown's existing x-show binding renders results
+                // as they arrive; a full-screen busy overlay on every
+                // keystroke would interrupt the user mid-typing, which is
+                // what triggered ABN-422. The outer @input.debounce.500ms
+                // already throttles input; the prior setTimeout(200) was
+                // a redundant second-stage delay and is gone.
+                try {
+                    const queryParams = new URLSearchParams({
+                        country: this.countryCode.toUpperCase(),
+                        limit: this.companySearchLimit,
+                        offset: 0,
+                        q: unescape(this.search),
+                    });
 
-                        const response = await fetch(this.checkoutApiUrl + '/companies/v2/company?' + queryParams);
-                        if (!response.ok) throw new Error("Network response was not ok");
+                    const response = await fetch(this.checkoutApiUrl + '/companies/v2/company?' + queryParams);
+                    if (!response.ok) throw new Error("Network response was not ok");
 
-                        const data = await response.json();
-                        this.items = data.items.map(item => ({
-                            companyName: item.name,
-                            companyDisplayName: `${item.highlight} (${item.national_identifier.id})`,
-                            companyId: item.national_identifier.id,
-                            lookupId: item.lookup_id,
-                            item: item
-                        }));
+                    const data = await response.json();
+                    this.items = data.items.map(item => ({
+                        companyName: item.name,
+                        companyDisplayName: `${item.highlight} (${item.national_identifier.id})`,
+                        companyId: item.national_identifier.id,
+                        lookupId: item.lookup_id,
+                        item: item
+                    }));
 
-                        if (this.items.length > 0) this.isOpen = true;
-                    } catch (error) {
-                        console.error("Error fetching companies:", error);
-                        this.items = [];
-                    }
-                    window.dispatchEvent(new Event('magewire:loader:done'));
-                }, 200);
+                    if (this.items.length > 0) this.isOpen = true;
+                } catch (error) {
+                    console.error("Error fetching companies:", error);
+                    this.items = [];
+                }
             },
 
             handleItemClick(event) {

--- a/view/frontend/templates/component/payment/method/gateway_method.phtml
+++ b/view/frontend/templates/component/payment/method/gateway_method.phtml
@@ -171,7 +171,7 @@ $showSingleTerm = $magewire->showChip && count($magewire->availableTerms) === 1;
                         <div class="w-full" @click.outside="<?= $gwBase ?>OnCompanySearchClickOutside">
                             <input
                                 type="text"
-                                @input.debounce="getItems"
+                                @input.debounce.500ms="getItems"
                                 @focus="<?= $gwBase ?>OnCompanySearchFocus"
                                 @keydown.arrow-down="<?= $gwBase ?>OnArrowDown"
                                 @keydown.arrow-up="<?= $gwBase ?>OnArrowUp"

--- a/view/frontend/templates/component/payment/method/gateway_method.phtml
+++ b/view/frontend/templates/component/payment/method/gateway_method.phtml
@@ -35,68 +35,47 @@ $quoteDetails = json_encode(
 );
 
 $showChip = $magewire->showChip && count($magewire->availableTerms) > 1;
-$showSingleTerm = $magewire->showChip && count($magewire->availableTerms) === 1;
 ?>
 <div
      x-data="<?= $gwBase ?>PaymentMethodBase" class="space-y-4 p-4 bg-white shadow-md rounded-lg payment-method-custom-form mb-6">
     <div class="redirect_message" data-bind="text: redirectMessage"><?= $configModel->getRedirectMessage() ?>
     </div>
-    <?php if ($showChip || $showSingleTerm): ?>
+    <?php if ($showChip): ?>
         <div class="two-term-chips field">
-            <?php if ($showChip): ?>
-                <label class="label block text-sm font-medium text-gray-700 mb-1">
-                    <span><?= $escaper->escapeHtml(__('Selected payment terms')) ?></span>
-                </label>
-                <div class="two-term-chips__container" role="group"
-                     aria-label="<?= $escaper->escapeHtmlAttr(__('Payment Terms')) ?>">
-                    <?php
-                    // Singular is built by prepending '1' to the translated 'day'
-                    // unit; saves a separate '1 day' CSV key since the numeral is
-                    // language-invariant.
-                    $singularLabel = '1 ' . __('day');
-                    $pluralLabel = __('%1 days');
-                    $errorMessage = __('Could not update payment term.') . ' ' . __('Please try again.');
-                    ?>
-                    <?php foreach ($magewire->availableTerms as $days): ?>
-                        <button type="button"
-                                x-data="<?= $gwBase ?>TermChip"
-                                data-days="<?= (int) $days ?>"
-                                data-label-singular="<?= $escaper->escapeHtmlAttr($singularLabel) ?>"
-                                data-label-plural="<?= $escaper->escapeHtmlAttr($pluralLabel) ?>"
-                                data-error-message="<?= $escaper->escapeHtmlAttr($errorMessage) ?>"
-                                :class="chipClasses"
-                                :aria-pressed="ariaPressed"
-                                :disabled="anyUpdating"
-                                @click="select">
-                            <span class="two-term-chip__days" x-text="label"></span>
-                            <template x-if="isLoading">
-                                <span class="two-term-chip__loading" aria-hidden="true"><span>.</span><span>.</span><span>.</span></span>
-                            </template>
-                            <template x-if="surchargeTextWhenNotLoading">
-                                <span class="two-term-chip__surcharge" x-text="surchargeTextWhenNotLoading"></span>
-                            </template>
-                        </button>
-                    <?php endforeach ?>
-                </div>
-            <?php else: ?>
+            <label class="label block text-sm font-medium text-gray-700 mb-1">
+                <span><?= $escaper->escapeHtml(__('Selected payment terms')) ?></span>
+            </label>
+            <div class="two-term-chips__container" role="group"
+                 aria-label="<?= $escaper->escapeHtmlAttr(__('Payment Terms')) ?>">
                 <?php
-                $singleDays = (int) reset($magewire->availableTerms);
+                // Singular is built by prepending '1' to the translated 'day'
+                // unit; saves a separate '1 day' CSV key since the numeral is
+                // language-invariant.
                 $singularLabel = '1 ' . __('day');
                 $pluralLabel = __('%1 days');
+                $errorMessage = __('Could not update payment term.') . ' ' . __('Please try again.');
                 ?>
-                <div class="two-term-chips__container">
-                    <span x-data="<?= $gwBase ?>TermChip"
-                          data-days="<?= $singleDays ?>"
-                          data-label-singular="<?= $escaper->escapeHtmlAttr($singularLabel) ?>"
-                          data-label-plural="<?= $escaper->escapeHtmlAttr($pluralLabel) ?>"
-                          class="two-term-chip two-term-chip--single">
+                <?php foreach ($magewire->availableTerms as $days): ?>
+                    <button type="button"
+                            x-data="<?= $gwBase ?>TermChip"
+                            data-days="<?= (int) $days ?>"
+                            data-label-singular="<?= $escaper->escapeHtmlAttr($singularLabel) ?>"
+                            data-label-plural="<?= $escaper->escapeHtmlAttr($pluralLabel) ?>"
+                            data-error-message="<?= $escaper->escapeHtmlAttr($errorMessage) ?>"
+                            :class="chipClasses"
+                            :aria-pressed="ariaPressed"
+                            :disabled="anyUpdating"
+                            @click="select">
                         <span class="two-term-chip__days" x-text="label"></span>
-                        <template x-if="surchargeText">
-                            <span class="two-term-chip__surcharge" x-text="surchargeText"></span>
+                        <template x-if="isLoading">
+                            <span class="two-term-chip__loading" aria-hidden="true"><span>.</span><span>.</span><span>.</span></span>
                         </template>
-                    </span>
-                </div>
-            <?php endif ?>
+                        <template x-if="surchargeTextWhenNotLoading">
+                            <span class="two-term-chip__surcharge" x-text="surchargeTextWhenNotLoading"></span>
+                        </template>
+                    </button>
+                <?php endforeach ?>
+            </div>
         </div>
     <?php endif ?>
     <?php

--- a/view/frontend/templates/form/field/companyName.phtml
+++ b/view/frontend/templates/form/field/companyName.phtml
@@ -53,7 +53,7 @@ $form = $block->getData("form");
                 data-validate='{"required":true}'
             <?php endif; ?>
             autocomplete="off"
-            @input.debounce.200ms="getItems"
+            @input.debounce.500ms="getItems"
             />
             <!-- Search for company link (shows in manual mode) -->
             <div x-show="manualMode" class="mt-1 text-right">


### PR DESCRIPTION
## Context

Three Hyva-side defects bundled into PR #32 per the ABN-422/424/428/429/433 multi-PR coordination plan. One commit per ticket.

## Changes

- **ABN-422** (commit `9761d88`) — Align Hyva company-search UX with Luma:
  - `@input.debounce` → `@input.debounce.500ms` on both the payment-method company input and the shipping-address `companyName.phtml` renderer.
  - Drop the inner `setTimeout(200)` wrapper around the search fetch and stop dispatching `magewire:loader:start/done` (no more full-screen overlay on every keystroke). The dropdown's existing `x-show` binding provides inline feedback.

- **ABN-428** (commit `be0dd26`) — Extend `BrandedHyvaViewModelInterface` with `getPaymentTermsMessage(string $termsLink, string $brandTermsName): Phrase`, letting brand overlays own the full T&C-acceptance sentence (some brands omit the link, change wording, or render regulatory phrasing).
  - Default Two impl reproduces the existing "By checking this box, I confirm that I have read and agree to %1." pattern.
  - `CheckoutConfig::getpaymentTermsMessage()` now builds the link + brand-terms phrase and delegates to the brand viewmodel.

- **ABN-429** (commit `5260b74`) — Decouple term-chip visibility from fee-sharing config in `Magewire\Checkout\Payment\GatewayMethod::hydrateChipState()`. Chips now render whenever the merchant has configured >0 payment terms; the surcharge type only gates per-chip surcharge value computation (the Alpine `x-if` on `surchargeTextWhenNotLoading` already handles the empty case).

## Scope / Non-goals

- No vanilla brand-name strings in `Two_GatewayHyva` code (brand-isolation invariant preserved — the ABN regulatory phrasing lives in the ABN brand viewmodel, not here).
- No changes to the Luma checkout — these are Hyva-only.
- The orphaned `tooltip.phtml` referenced by ABN's deleted layout block lives in `magento-abn-plugin` and is left for a follow-up cleanup.

## Cross-repo coordination

- **`two-inc/magento-abn-plugin#121`** — ABN-424 (tooltip-icon removal) + ABN-428 ABN brand impl. **Merge that PR first**, then this one — the AbnBrandedHyvaViewModel must already implement `getPaymentTermsMessage` before the interface contract requires it.
- **`two-inc/magento-plugin#186`** — ABN-433 (admin Dutch comma decimal). Independent surface; merge order does not matter.

## Validation

- Local PHP lint: `php` not available in dev env — relies on CI.
- Manual staging test plan after deploy:
  - ABN-422: type into both company-search inputs on Hyva, confirm no full-screen loader and ~500ms debounce.
  - ABN-428: select abn_payment, confirm the T&C label reads the new Dutch regulatory sentence (renders via the ABN PR's brand impl).
  - ABN-429: with merchant config `payment/<code>/surcharge_type = none` and `payment_terms` set to two or more terms, confirm the term chips render. Switch surcharge_type → fixed/percentage and confirm per-chip surcharge values reappear.

## Tickets

- <https://linear.app/tillit/issue/ABN-422>
- <https://linear.app/tillit/issue/ABN-428>
- <https://linear.app/tillit/issue/ABN-429>