### PR TITLE
ABN-428/followup: align Hyva T&C with Luma — drop Hyva-only source phrase

### DIFF
--- a/ViewModel/BrandedHyvaViewModelInterface.php
+++ b/ViewModel/BrandedHyvaViewModelInterface.php
@@ -52,10 +52,12 @@ interface BrandedHyvaViewModelInterface extends ArgumentInterface
      *
      * @param string $termsLink Absolute URL to the brand's terms page,
      *     supplied by the caller so the interface stays free of
-     *     ConfigRepository dependencies.
-     * @param string $brandTermsName Human-readable phrase used as the
-     *     anchor text in brands that render a link (e.g. "Two terms
-     *     and conditions").
+     *     ConfigRepository dependencies. Used as the `href` of the
+     *     hyperlink that wraps the translated "payment terms" phrase.
+     * @param string $brandFullName Legal/full brand name surfaced in
+     *     the sentence (e.g. "Two" or "ABN AMRO Asset Based Finance
+     *     N.V.") — the entity the buyer is authorising to process
+     *     their data.
      */
-    public function getPaymentTermsMessage(string $termsLink, string $brandTermsName): Phrase;
+    public function getPaymentTermsMessage(string $termsLink, string $brandFullName): Phrase;
 }

--- a/ViewModel/CheckoutConfig.php
+++ b/ViewModel/CheckoutConfig.php
@@ -238,15 +238,11 @@ class CheckoutConfig implements ArgumentInterface
 
     public function getpaymentTermsMessage()
     {
-        $paymentTerms = __(
-            "%1 terms and conditions",
-            $this->brandRegistry->getProvider(),
-        );
         $paymentTermsLink =
             $this->configRepository->getCheckoutPageUrl() . "/terms";
         return $this->brandedViewModel->getPaymentTermsMessage(
             $paymentTermsLink,
-            (string) $paymentTerms,
+            $this->brandRegistry->getProviderFullName(),
         );
     }
 

--- a/ViewModel/TwoBrandedHyvaViewModel.php
+++ b/ViewModel/TwoBrandedHyvaViewModel.php
@@ -28,15 +28,21 @@ final class TwoBrandedHyvaViewModel implements BrandedHyvaViewModelInterface
         return 'checkout.payment.method.two-payment-method';
     }
 
-    public function getPaymentTermsMessage(string $termsLink, string $brandTermsName): Phrase
+    public function getPaymentTermsMessage(string $termsLink, string $brandFullName): Phrase
     {
+        // Mirror the Luma ConfigProvider's T&C-acceptance pattern so
+        // Two-brand renders the same source phrase on both Luma and
+        // Hyva checkouts — no Luma↔Hyva copy divergence. %1 is the
+        // translated "payment terms" phrase wrapped in an anchor;
+        // %2 is the brand's legal full name from brand.xml.
         return __(
-            "By checking this box, I confirm that I have read and agree to %1.",
+            'I accept the %1 and authorize %2 to process my data automatically.',
             sprintf(
                 '<a class="text-blue-600" href="%s" target="_blank">%s</a>',
                 $termsLink,
-                $brandTermsName,
+                __('payment terms'),
             ),
+            $brandFullName,
         );
     }
 }


### PR DESCRIPTION
## Context

Follow-up to ABN-428. The original PR series introduced a brand-overridable `getPaymentTermsMessage` on `BrandedHyvaViewModelInterface` so ABN could ship its own T&C copy. While reviewing the deployed staging, Doug spotted that:

1. The Luma equivalent renders the `betaalvoorwaarden` word as a hyperlink to the brand's terms page (via `Model/Ui/ConfigProvider::paymentTermsMessage`), but the Hyva override I shipped omitted the link.
2. The vanilla Two-brand Hyva impl still used a Hyva-only source phrase — `"By checking this box, I confirm that I have read and agree to %1."` — which surfaced different copy to Two-brand buyers on Hyva vs Luma.

This PR aligns Hyva with Luma's existing pattern.

## Changes

- `BrandedHyvaViewModelInterface::getPaymentTermsMessage()` argument renamed `$brandTermsName` → `$brandFullName` for semantic clarity (the value is the legal entity name, not the "X terms and conditions" phrase).
- `TwoBrandedHyvaViewModel::getPaymentTermsMessage()` rewritten to use Luma's source phrase: `"I accept the %1 and authorize %2 to process my data automatically."`. %1 is the translated `"payment terms"` phrase wrapped in an anchor pointing at the brand's terms page; %2 is the brand's legal full name from `brand.xml`.
- `CheckoutConfig::getpaymentTermsMessage()` rewired to pass `$paymentTermsLink` + `brandRegistry->getProviderFullName()` (was `$paymentTermsLink + "%1 terms and conditions" phrase`).

## Side effect

The source phrase `"By checking this box, I confirm that I have read and agree to %1."` is no longer emitted by any code path in this module. It can be dropped from the brand-neutral `magento-plugin` i18n CSVs — covered by companion PR `two-inc/magento-plugin#…`.

## Cross-repo coordination

- **`two-inc/magento-abn-plugin` branch `doug/abn-428-followup-abn-link-wrap`** — ABN brand-impl matching parameter rename + link-wrap conversion. Renders byte-identical HTML to Luma's ConfigProvider so the buyer sees the hyperlinked `betaalvoorwaarden`.
- **`two-inc/magento-plugin` branch `doug/abn-428-followup-drop-orphan-tc-source`** — drops the orphan NL / NO / SE translations of the retired source phrase.

Recommended merge order:
1. `magento-abn-plugin` PR — ABN impl matches both the pre- and post-rename interface shape because PHP doesn't enforce parameter names; merging first is safe.
2. `magento-hyva-extension` PR (this one) — applies the interface rename + Two impl realignment.
3. `magento-plugin` PR — drops the now-orphan translations once nothing emits them.

## Ticket

- https://linear.app/tillit/issue/ABN-428