### PR TITLE
ABN-422/fix: bind :data-index on payment company dropdown items

### DIFF
--- a/view/frontend/templates/component/payment/method/gateway_method.phtml
+++ b/view/frontend/templates/component/payment/method/gateway_method.phtml
@@ -179,6 +179,7 @@ $showChip = $magewire->showChip && count($magewire->availableTerms) > 1;
                                         :key="<?= $gwBase ?>GetCompanyId"
                                     >
                                         <div
+                                            :data-index="index"
                                             @click="<?= $gwBase ?>OnCompanyItemClick"
                                             @mouseover="<?= $gwBase ?>OnItemMouseover"
                                             :class="<?= $gwBase ?>GetItemClass"


### PR DESCRIPTION
## Context

ABN-422 follow-up. On Hyva checkout (both Two and ABN brands), the payment-method
Company-Name dropdown rendered search results but clicking a result did nothing —
dropdown stayed open, no company selected.

## Changes

- `view/frontend/templates/component/payment/method/gateway_method.phtml`:
  add `:data-index="index"` to the dropdown item div inside the `x-for` loop.

## Scope / Non-goals

- Does not touch the shipping-address company-search dropdown (already works).
- Does not touch ABN overlay — this is a vanilla Hyva bug; ABN inherits the fix.
- No JS / handler logic changes.

## Validation

- Repro on `magento.staging.achterafbetalen.co/hyva/checkout`: pre-fix click was
  no-op; post-fix click sets `company_name="TES"` and `company_id="82556075"`
  and closes the dropdown.
- The handler being called is `handleItemClick(event)`, which reads
  `event.currentTarget.dataset.index` to look up `this.items[index]`. The
  shipping-form dropdown already binds `:data-index="index"` and the same
  handler works there.

## Ticket

- <https://linear.app/tillit/issue/ABN-422>

🤖 Generated with [Claude Code](https://claude.com/claude-code)