### PR TITLE
ABN-438/fix: correct Hyva payment subtitle text

### DIFF
--- a/view/frontend/templates/component/payment/method/gateway_method.phtml
+++ b/view/frontend/templates/component/payment/method/gateway_method.phtml
@@ -38,8 +38,7 @@ $showChip = $magewire->showChip && count($magewire->availableTerms) > 1;
 ?>
 <div
      x-data="<?= $gwBase ?>PaymentMethodBase" class="space-y-4 p-4 bg-white shadow-md rounded-lg payment-method-custom-form mb-6">
-    <div class="redirect_message" data-bind="text: redirectMessage"><?= $configModel->getRedirectMessage() ?>
-    </div>
+    <div class="two-payment-subtitle"><?= /* @noEscape */ __("For all companies.") ?></div>
     <?php if ($showChip): ?>
         <div class="two-term-chips field">
             <label class="label block text-sm font-medium text-gray-700 mb-1">


### PR DESCRIPTION
## Context

ABN-438: the Hyva checkout undertext below **"Zakelijk op Rekening"** showed **"Bestel nu, ontvang je goederen, betaal later je factuur."** — the translation of `getRedirectMessage()` ("Buy now, receive your goods, pay your invoice later."). That's the wrong content.

Root cause: Luma renders the `two-payment-subtitle` (`__("For all companies.")` → nl_NL `"Voor alle bedrijven, lees meer."`) under the payment title. Hyva never picked up the ABN-298 subtitle and instead rendered the redirect message in that slot. The `data-bind="text: redirectMessage"` was also a dead Knockout binding (Hyva uses Alpine/Magewire), so only the static PHP-rendered text ever showed.

## Changes

- `view/frontend/templates/component/payment/method/gateway_method.phtml`: replace the `redirect_message` div with a `two-payment-subtitle` div rendering `__("For all companies.")`, matching Luma.

## Scope / Non-goals

- Shared `Two_GatewayHyva` template — ABN does **not** override it. Fix lands here, correcting ABN Hyva **and** bringing vanilla Two Hyva into parity with Two Luma (which already shows this subtitle).
- `CheckoutConfig::getRedirectMessage()` left intact (now unused by templates, harmless; removal is out of scope).
- No CSS for `.redirect_message` existed, so no styling regression.

## Validation

- `__("For all companies.")` resolves per brand via existing i18n: ABN `nl_NL.csv` → `"Voor alle bedrijven, lees meer."` (matches ticket expected); vanilla Two → English source (matches Two Luma).
- Pending: deploy-verify on staging via git-sync + hard reload after merge.

## Ticket

- https://linear.app/tillit/issue/ABN-438