### PR TITLE
ABN-440/fix: brand-supplied Hyva subtitle (require parent ^2.0)

### DIFF
--- a/ViewModel/CheckoutConfig.php
+++ b/ViewModel/CheckoutConfig.php
@@ -199,6 +199,21 @@ class CheckoutConfig implements ArgumentInterface
         return $redirectMessage;
     }
 
+    /**
+     * Brand-supplied checkout subtitle, rendered under the payment title.
+     *
+     * The string is brand data (BrandRegistryInterface::getCheckoutSubtitle,
+     * from brand.xml). The vanilla Two brand returns '' → no subtitle. Only
+     * a non-empty key is passed to the translator, so an unmapped locale
+     * falls back to the brand-owned source key rather than leaking a
+     * vanilla key. May contain HTML (e.g. a link) — render unescaped.
+     */
+    public function getCheckoutSubtitleHtml(): string
+    {
+        $key = $this->brandRegistry->getCheckoutSubtitle();
+        return $key === '' ? '' : (string)__($key);
+    }
+
     public function getOrderIntentApprovedMessage()
     {
         $orderIntentApprovedMessage = __(

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "magento2-module",
   "version": "1.14.2",
   "require": {
-    "two-inc/magento2": "^1.13.1",
+    "two-inc/magento2": "^2.0",
     "hyva-themes/magento2-hyva-checkout": "^1.3"
   },
   "autoload": {

--- a/view/frontend/templates/component/payment/method/gateway_method.phtml
+++ b/view/frontend/templates/component/payment/method/gateway_method.phtml
@@ -38,8 +38,7 @@ $showChip = $magewire->showChip && count($magewire->availableTerms) > 1;
 ?>
 <div
      x-data="<?= $gwBase ?>PaymentMethodBase" class="space-y-4 p-4 bg-white shadow-md rounded-lg payment-method-custom-form mb-6">
-    <div class="redirect_message" data-bind="text: redirectMessage"><?= $configModel->getRedirectMessage() ?>
-    </div>
+    <div class="two-payment-subtitle"><?= /* @noEscape */ $configModel->getCheckoutSubtitleHtml() ?></div>
     <?php if ($showChip): ?>
         <div class="two-term-chips field">
             <label class="label block text-sm font-medium text-gray-700 mb-1">


### PR DESCRIPTION
## Context

Part 3 of 3 (with `magento-plugin` #196 and `magento-abn-plugin`). The Hyva payment body rendered `getRedirectMessage()` ("Buy now, receive your goods, pay your invoice later.") as the undertext under the payment title. Luma renders a brand subtitle there; Hyva should too — but the text must be **brand data**: empty for vanilla Two, supplied by a brand overlay. Supersedes the hardcoded `"For all companies."` in #35 (to be closed).

## Changes

- **`composer.json`**: `two-inc/magento2` `^1.13.1` → `^2.0` — Hyva now relies on the 2.x `BrandRegistry::getCheckoutSubtitle()` structure (would fail on a pre-2.0 parent).
- **`CheckoutConfig::getCheckoutSubtitleHtml()`**: reads the active brand's subtitle from the already-injected `BrandRegistry`; `''` for vanilla, `__()`'d only when non-empty (unmapped locale → brand-owned source key, never a vanilla key).
- **`gateway_method.phtml`**: replaces the `redirect_message` div with a `two-payment-subtitle` div bound to the brand subtitle (empty → no text).

Single source: the parent brand.xml `<checkout_subtitle>` value, shared by Luma and Hyva.

## Scope / Non-goals

- Depends on #196 (parent `getCheckoutSubtitle`) and the ABN brand.xml node, deployed via git-sync. No blocking CI in this repo (advisory review only).

## Validation

- composer.json valid JSON. Behaviour verified end-to-end in browser post-deploy: vanilla Two → empty subtitle; ABN → its subtitle.

## Ticket

- https://linear.app/tillit/issue/ABN-440