### PR TITLE
ABN-440/fix: style Hyva subtitle link (blue + underlined)

### DIFF
--- a/view/frontend/web/css/custom.css
+++ b/view/frontend/web/css/custom.css
@@ -177,3 +177,15 @@ summary::marker {
    caption and the chip strip. Tailwind utility `mb-1` on the label is
    too tight visually. */
 .two-term-chips > label.label { margin-bottom: 20px; }
+
+/* Brand checkout subtitle under the payment-method title. The text is
+   brand-supplied (BrandRegistry::getCheckoutSubtitle) and may contain a
+   link (e.g. ABN's "lees meer"). Hyva's Tailwind base resets <a> to
+   inherit colour with no underline, so the link rendered as plain text.
+   Restore Luma's appearance (style.css `.two-payment-subtitle a`): blue +
+   underlined. Class+element specificity beats Tailwind's element-only
+   reset, so no !important needed. */
+.two-payment-subtitle a {
+    color: #0066cc;
+    text-decoration: underline;
+}


### PR DESCRIPTION
## Context

Follow-up to #36. The brand subtitle now renders on Hyva checkout, but its link (ABN's "lees meer") showed as **plain text** — Hyva's Tailwind base resets `<a>` to inherit colour, no underline. Luma renders it blue + underlined (`style.css .two-payment-subtitle a`).

## Changes

- `view/frontend/web/css/custom.css`: add `.two-payment-subtitle a { color:#0066cc; text-decoration:underline; }`, matching Luma. `custom.css` is already loaded on the Hyva checkout. Class+element specificity beats Tailwind's element-only reset — no `!important`.

## Validation

- Browser: ABN Hyva checkout subtitle link now blue + underlined, matching Luma.

## Ticket
- https://linear.app/tillit/issue/ABN-440