### PR TITLE
ABN-442/fix: align Hyva term-fee display with Luma

### DIFF
--- a/view/frontend/templates/component/payment/method/gateway_method-csp-js.phtml
+++ b/view/frontend/templates/component/payment/method/gateway_method-csp-js.phtml
@@ -818,10 +818,22 @@ $quoteDetails = json_encode($quoteDetails);
 
             get surchargeText() {
                 const surcharges = this.$wire.termSurcharges || {};
+                const terms = Object.keys(surcharges);
+                // Empty map → surcharges not yet loaded; show nothing.
+                if (!terms.length) return '';
                 const raw = surcharges[this.days];
                 if (raw === undefined) return '';
-                const amount = parseFloat(raw);
-                if (!isFinite(amount) || amount <= 0) return '';
+                // Match Luma (gateway_method.js `termOptions`): if EVERY
+                // term is ~zero, show no fee on any chip; if ANY term is
+                // non-zero, show the fee on every chip — zero-fee chips
+                // then render `+€ 0.00`. The `< 0.005` threshold and the
+                // `+` prefix mirror the Luma renderer exactly so the two
+                // checkouts display identically.
+                const allZero = terms.every(function (days) {
+                    return parseFloat(surcharges[days] || 0) < 0.005;
+                });
+                if (allZero) return '';
+                const amount = parseFloat(raw || 0);
                 const currency = this.$wire.currencyCode || 'EUR';
                 // Use the Magento store-view locale piped from PHP
                 // (`nl-NL`, `en-GB`, ...) so the chip's currency format
@@ -829,12 +841,12 @@ $quoteDetails = json_encode($quoteDetails);
                 // produce `€16.03` while Magento formats `€ 16,03`.
                 const locale = this.$wire.currencyLocale || undefined;
                 try {
-                    return new Intl.NumberFormat(locale, {
+                    return '+' + new Intl.NumberFormat(locale, {
                         style: 'currency',
                         currency: currency
                     }).format(amount);
                 } catch (e) {
-                    return amount.toFixed(2);
+                    return '+' + amount.toFixed(2);
                 }
             },
 


### PR DESCRIPTION
## What

Aligns the Hyvä term-chip fee display with the Luma checkout's existing behaviour.

## Why

The two checkouts diverged when **some but not all** payment terms carry a surcharge:

| Scenario | Luma (reference) | Hyvä (before) |
|---|---|---|
| All terms zero-fee | no fee on any chip | no fee on any chip ✅ |
| Some terms have a fee | fee on **all** chips, `+€ 0.00` on zero-fee ones | fee on **only** the non-zero chips ❌ |

A secondary divergence: Luma prefixes the amount with `+` (`+€ 16,03`); Hyvä rendered `€ 16,03` with no `+`. Since the agreed target string is `+€ 0.00`, the `+` is now added to every chip for consistency.

## How

Replicates Luma's `view/frontend/web/js/view/payment/method-renderer/gateway_method.js` `termOptions` logic inside the per-chip Alpine getter (`gateway_method-csp-js.phtml`, `TermChip.surchargeText`):

- visibility decided across the **whole** surcharge set — `allZero` via the `< 0.005` threshold (mirrors Luma) — rather than per-chip
- `+` prefix on every chip's formatted amount
- loading (empty map) and single-term states fall out of the same logic unchanged; currency formatting still uses the store-view `Intl` locale, untouched

## Verification

No JS unit harness exists for `.phtml`-embedded Alpine getters in this repo. Logic verified standalone in Node across: empty map, all-zero, mixed (zero + non-zero chips), single zero, single non-zero, and sub-threshold (`0.004`) cases — all match Luma. The mixed-set zero chip now renders exactly `+€ 0,00`.

Behavioural check on staging still recommended once deployed (git-sync tracks `staging`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)