### PR TITLE
ABN-439/fix: render single available payment term as a chip (match Luma)

### DIFF
--- a/Magewire/Checkout/Payment/GatewayMethod.php
+++ b/Magewire/Checkout/Payment/GatewayMethod.php
@@ -59,6 +59,8 @@ class GatewayMethod extends Component
 
     public bool $showChip = false;
 
+    public bool $showSingleTerm = false;
+
     protected $loader = true;
 
     /**
@@ -213,15 +215,17 @@ class GatewayMethod extends Component
             // Chips visibility is driven by available payment terms alone.
             // Surcharge type only gates per-chip surcharge value display —
             // term selection is a buyer choice independent of fee sharing.
-            // Single-term configs render nothing — with one option there
-            // is nothing for the buyer to select.
+            // A single available term renders one informational (non-clickable)
+            // chip, preselected — matching Luma (ABN-439).
             $this->showChip = count($terms) > 1;
-            $this->termSurcharges = ($this->showChip && $type !== SurchargeType::NONE)
+            $this->showSingleTerm = count($terms) === 1;
+            $this->termSurcharges = (($this->showChip || $this->showSingleTerm) && $type !== SurchargeType::NONE)
                 ? $this->computeAllTermSurcharges($quote, $terms)
                 : [];
         } catch (\Exception $e) {
             $this->logRepository->addErrorLog('Hyva chip: hydrate failed', $e->getMessage());
             $this->showChip = false;
+            $this->showSingleTerm = false;
             $this->availableTerms = [];
             $this->termSurcharges = [];
             $this->currencyCode = '';

--- a/view/frontend/templates/component/payment/method/gateway_method-csp-js.phtml
+++ b/view/frontend/templates/component/payment/method/gateway_method-csp-js.phtml
@@ -775,9 +775,13 @@ $quoteDetails = json_encode($quoteDetails);
             labelPlural: '%1 days',
             errorMessage: 'Could not update payment term. Please try again.',
             isUpdating: false,
+            single: false,
 
             init() {
                 this.days = parseInt(this.$el.dataset.days, 10) || 0;
+                // `single` marks the sole-available-term chip: informational,
+                // not clickable, distinct --single styling (matches Luma).
+                this.single = this.$el.dataset.single === '1';
                 // Translated labels sourced from PHP via __(); CSV strings
                 // live in the plugin's i18n/<locale>.csv files.
                 if (this.$el.dataset.labelSingular) this.labelSingular = this.$el.dataset.labelSingular;
@@ -807,6 +811,9 @@ $quoteDetails = json_encode($quoteDetails);
             },
 
             get chipClasses() {
+                if (this.single) {
+                    return 'two-term-chip two-term-chip--single';
+                }
                 return this.isSelected
                     ? 'two-term-chip two-term-chip--selected'
                     : 'two-term-chip';
@@ -863,6 +870,7 @@ $quoteDetails = json_encode($quoteDetails);
             },
 
             async select() {
+                if (this.single) return; // sole term — nothing to switch to
                 if (Alpine.store('twoChip').busy) return;
                 if (this.isSelected) return;
 

--- a/view/frontend/templates/component/payment/method/gateway_method.phtml
+++ b/view/frontend/templates/component/payment/method/gateway_method.phtml
@@ -76,6 +76,36 @@ $showChip = $magewire->showChip && count($magewire->availableTerms) > 1;
                 <?php endforeach ?>
             </div>
         </div>
+    <?php elseif ($magewire->showSingleTerm): ?>
+        <?php
+        // Single available term: one informational, non-clickable chip,
+        // preselected — matching Luma. Reuses the TermChip component (label +
+        // surcharge formatting) in `single` mode (--single styling, no click).
+        $singleDay = (int) ($magewire->availableTerms[0] ?? 0);
+        $singularLabel = '1 ' . __('day');
+        $pluralLabel = __('%1 days');
+        ?>
+        <div class="two-term-chips field">
+            <label class="label block text-sm font-medium text-gray-700 mb-1">
+                <span><?= $escaper->escapeHtml(__('Selected payment terms')) ?></span>
+            </label>
+            <div class="two-term-chips__container">
+                <span x-data="<?= $gwBase ?>TermChip"
+                      data-days="<?= $singleDay ?>"
+                      data-single="1"
+                      data-label-singular="<?= $escaper->escapeHtmlAttr($singularLabel) ?>"
+                      data-label-plural="<?= $escaper->escapeHtmlAttr($pluralLabel) ?>"
+                      :class="chipClasses">
+                    <span class="two-term-chip__days" x-text="label"></span>
+                    <template x-if="isLoading">
+                        <span class="two-term-chip__loading" aria-hidden="true"><span>.</span><span>.</span><span>.</span></span>
+                    </template>
+                    <template x-if="surchargeTextWhenNotLoading">
+                        <span class="two-term-chip__surcharge" x-text="surchargeTextWhenNotLoading"></span>
+                    </template>
+                </span>
+            </div>
+        </div>
     <?php endif ?>
     <?php
     /*

--- a/view/frontend/web/css/custom.css
+++ b/view/frontend/web/css/custom.css
@@ -114,6 +114,24 @@ summary::marker {
   color: #fff;
 }
 
+/* Sole-available-term chip: informational, not interactive. Blue border
+   (like the selected chip) but no fill and no checkmark — matches Luma's
+   two-term-chip--single. */
+.two-term-chip--single,
+.two-term-chip--single:hover {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  border-color: #3043d1;
+  cursor: default;
+}
+
+.two-term-chip--single .two-term-chip__surcharge {
+  font-size: 14px;
+  font-weight: 500;
+  opacity: 1;
+}
+
 .two-term-chip__days {
   font-size: 14px;
   font-weight: 500;


### PR DESCRIPTION
Hyva showed **no chip** for a single available term (`showChip = count > 1`); Luma shows a single informational chip. Now:
- Magewire exposes `showSingleTerm` (count === 1) and computes the single term's surcharge.
- Template renders one non-clickable `two-term-chip--single`, reusing the `TermChip` Alpine component (label + surcharge formatting) in a new `single` mode.
- `--single` CSS added (blue border, no fill/checkmark), mirroring Luma.

Preselection: the single term is always the default — fixed in the shared magento-plugin config (two-inc/magento-plugin#209), so the chip is preselected on both checkouts. Refs ABN-439