### PR TITLE
ABN-450/fix: block Place Order on invalid payment form, clear stale errors

### DIFF
--- a/view/frontend/templates/component/payment/method/gateway_method-csp-js.phtml
+++ b/view/frontend/templates/component/payment/method/gateway_method-csp-js.phtml
@@ -85,9 +85,18 @@ $quoteDetails = json_encode($quoteDetails);
                         clearTimeout(timeout);
 
                         if (isWithValidation) {
+                            // Clear stale flash messages from a prior attempt so a
+                            // resubmit doesn't render outdated errors (mirrors the
+                            // Luma renderer's messageContainer.clear() — ABN-450).
+                            // Hyva's stepTo() fires the same event when navigating.
+                            window.dispatchEvent(new Event('clear-messages'));
+
                             try {
                                 await this.validate();
                             } catch (error) {
+                                // Swallow so the autosave/navigation task resolves;
+                                // the validator registered in init() is what blocks
+                                // Place Order on an invalid form (ABN-450).
                                 console.error("Form validation failed:", error);
                                 return;
                             }
@@ -185,6 +194,35 @@ $quoteDetails = json_encode($quoteDetails);
                     hyvaCheckout.navigation.addTask(doSave, {
                         name: '<?= str_replace('checkout.payment.method.', '', $brandedViewModel->getMagewireBlockName()) ?>'
                     });
+
+                    // Block Place Order while the payment form is invalid
+                    // (ABN-450). The doSave task above swallows validation
+                    // failures (a rejected navigation task would abort with
+                    // Hyva's generic "Something went wrong" alert), so without
+                    // this validator order.place() proceeds with
+                    // setPaymentData skipped and the backend rejects the order
+                    // with a raw "Invalid organization number: ''" banner. A
+                    // false return aborts placement silently, leaving
+                    // hyva.formValidation's field-level messages (e.g.
+                    // terms-not-accepted) as the feedback.
+                    hyvaCheckout.validation.register(
+                        '<?= str_replace('checkout.payment.method.', '', $brandedViewModel->getMagewireBlockName()) ?>_form',
+                        async () => {
+                            const activePaymentMethod = document.querySelector('input[name="payment-method-option"]:checked');
+
+                            if (!activePaymentMethod || activePaymentMethod.value !== "<?= $brandedViewModel->getMethodCode() ?>") {
+                                return true;
+                            }
+
+                            try {
+                                await this.validate();
+                                return true;
+                            } catch (error) {
+                                return false;
+                            }
+                        },
+                        form
+                    );
 
                     const addEventListeners = (el) => {
                         if (el !== form) return;


### PR DESCRIPTION
Fixes [ABN-450](https://linear.app/tillit/issue/ABN-450).

## Root cause (confirmed against the QA screenshot)

The banner QA reported as "Invalid organisation" is checkout-api's raw pydantic message `Invalid organization number: ''` — an **empty** org number, while the KVK field visibly held a value. Chain:

1. `doSave` runs as a hyvaCheckout **navigation task** on Place Order and swallowed its own validation failure (`console.error` + return) — the task resolved, so placement proceeded with `setPaymentData` skipped.
2. Company fields are filled programmatically (`updatePaymentFields` sets `.value`, no input events), so Magewire autosave never persisted them either → backend created the Two order with an empty `organization_number` → SCHEMA_ERROR, loc unmapped, raw message rendered as a Magento session flash.
3. Nothing cleared that flash on resubmit. Luma got exactly this fix (`messageContainer.clear()` in `placeOrder`); the Hyva port never did.

The *correct* T&C message ("U moet ABN AMRO voorwaarden…") was already rendering under the checkbox via `data-msg-required` — the defect is the spurious banner on top, and its persistence.

## Fix

- Register a `hyvaCheckout.validation` validator (runs only when Two is the selected method, `el: form` so it auto-passes if unmounted): `order.place()` runs validators after navigation tasks and a `false` return aborts **silently**, leaving the field-level messages as the feedback. (A rejected navigation task instead triggers Hyva's generic "Something went wrong" alert — that's why doSave keeps swallowing.)
- Dispatch `clear-messages` on each validated save so stale flash banners from prior attempts are removed — same event Hyva's own `stepTo()` fires, handled by the theme's `messages.phtml`.

Verified against the deployed vendor sources on staging: `order.place()` task/validator ordering ( `v1.phtml:1030`), validator-false silent abort, and the `@clear-messages.window` listener (`Magento_Theme/templates/messages.phtml:82`).

## Testing

`php -l` clean. Needs staging QA pass: place order with T&C unticked → expect only the field message, no banner, order not placed; tick → order proceeds; no lingering banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)