### PR TITLE
TWO-24775/fix: Refresh payment method list on carrier selection

### DIFF
--- a/Magewire/Checkout/Payment/MethodList.php
+++ b/Magewire/Checkout/Payment/MethodList.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Two\GatewayHyva\Magewire\Checkout\Payment;
+
+use Hyva\Checkout\Magewire\Checkout\Payment\MethodList as HyvaMethodList;
+
+/**
+ * Hyva's payment method list refreshes on address and coupon changes
+ * but not on carrier selection, while the shipping cost is part of the
+ * basket value Two's minimum-order gate compares
+ * (Two\Gateway\Service\Order\MinimumOrderGate via Two::isAvailable()).
+ * Without this listener a carrier change that moves the basket across
+ * the minimum leaves a stale method list on screen until some other
+ * refresh event fires.
+ */
+class MethodList extends HyvaMethodList
+{
+    public function getListeners(): array
+    {
+        return array_merge(parent::getListeners(), [
+            'shipping_method_selected' => 'refresh',
+        ]);
+    }
+}

--- a/Test/Stubs/HyvaCheckoutPaymentMethodList.php
+++ b/Test/Stubs/HyvaCheckoutPaymentMethodList.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+// Faithful stubs of the Hyva/Magewire classes Two\GatewayHyva\Magewire\
+// Checkout\Payment\MethodList extends. The listener sets mirror the real
+// classes (hyva-checkout 1.x) so the merge semantics under test are the
+// ones production sees.
+
+namespace Magewirephp\Magewire {
+    if (!class_exists(Component::class, false)) {
+        class Component
+        {
+            /** @var array<string, string> */
+            protected $listeners = [];
+
+            public function getListeners(): array
+            {
+                return $this->listeners;
+            }
+        }
+    }
+}
+
+namespace Hyva\Checkout\Magewire\Checkout\Payment {
+    use Magewirephp\Magewire\Component;
+
+    if (!class_exists(MethodList::class, false)) {
+        class MethodList extends Component
+        {
+            protected $listeners = [
+                'billing_address_saved' => 'refresh',
+                'shipping_address_saved' => 'refresh',
+                'coupon_code_applied' => 'refresh',
+                'coupon_code_revoked' => 'refresh',
+            ];
+        }
+    }
+}

--- a/Test/Unit/Magewire/Checkout/Payment/MethodListTest.php
+++ b/Test/Unit/Magewire/Checkout/Payment/MethodListTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Two\GatewayHyva\Test\Unit\Magewire\Checkout\Payment;
+
+use PHPUnit\Framework\TestCase;
+use Two\GatewayHyva\Magewire\Checkout\Payment\MethodList;
+
+class MethodListTest extends TestCase
+{
+    /**
+     * The subclass must ADD the carrier-selection refresh, not replace
+     * Hyva's listener set — losing the address/coupon refreshes would
+     * silently freeze the method list on those events instead.
+     */
+    public function testListenersExtendHyvaSetWithShippingMethodSelected(): void
+    {
+        $listeners = (new MethodList())->getListeners();
+
+        $this->assertSame('refresh', $listeners['shipping_method_selected'] ?? null);
+        foreach (
+            [
+                'billing_address_saved',
+                'shipping_address_saved',
+                'coupon_code_applied',
+                'coupon_code_revoked',
+            ] as $inherited
+        ) {
+            $this->assertSame('refresh', $listeners[$inherited] ?? null, "lost inherited listener: $inherited");
+        }
+    }
+}

--- a/Test/bootstrap.php
+++ b/Test/bootstrap.php
@@ -5,3 +5,15 @@ declare(strict_types=1);
 // Minimal bootstrap for unit tests that don't need Magento DI.
 // Tests requiring Magento framework classes should add stubs under Test/Stubs/
 // and require them here.
+
+require __DIR__ . '/Stubs/HyvaCheckoutPaymentMethodList.php';
+
+spl_autoload_register(static function (string $class): void {
+    $prefix = 'Two\\GatewayHyva\\';
+    if (strncmp($class, $prefix, strlen($prefix)) === 0) {
+        $file = __DIR__ . '/../' . str_replace('\\', '/', substr($class, strlen($prefix))) . '.php';
+        if (is_file($file)) {
+            require $file;
+        }
+    }
+});

--- a/dev/stub-hyva
+++ b/dev/stub-hyva
@@ -94,6 +94,19 @@ class MethodMetaData extends DataObject
 }
 PHP,
 
+    'Hyva/Checkout/Magewire/Checkout/Payment/MethodList.php' => <<<'PHP'
+<?php
+namespace Hyva\Checkout\Magewire\Checkout\Payment;
+
+use Magewirephp\Magewire\Component;
+
+class MethodList extends Component
+{
+    protected $listeners = [];
+    public function getListeners(): array { return $this->listeners; }
+}
+PHP,
+
     'Hyva/Checkout/Model/ConfigData/HyvaThemes/SystemConfigPayment.php' => <<<'PHP'
 <?php
 namespace Hyva\Checkout\Model\ConfigData\HyvaThemes;

--- a/view/frontend/layout/hyva_checkout_components.xml
+++ b/view/frontend/layout/hyva_checkout_components.xml
@@ -14,6 +14,13 @@
                 template="Two_GatewayHyva::component/payment/method/shipping_company.phtml" after="-"/>
         </referenceBlock>
         <referenceBlock name="checkout.payment.methods">
+            <!-- Swap in our MethodList so the list refreshes when a carrier
+                 is selected (shipping cost feeds the minimum-order gate) -->
+            <arguments>
+                <argument name="magewire" xsi:type="object">
+                    Two\GatewayHyva\Magewire\Checkout\Payment\MethodList
+                </argument>
+            </arguments>
             <block name="checkout.payment.method.two-payment-method" as="two_payment" ifconfig="payment/two_payment/active" template="Two_GatewayHyva::component/payment/method/gateway_method.phtml">
                 <arguments>
                     <argument name="magewire" xsi:type="object">


### PR DESCRIPTION
## Why

Doug's staging repro: the payment method's show/hide decision (minimum-order gate, `Two\Gateway\Service\Order\MinimumOrderGate` via `Two::isAvailable()`) goes stale at checkout. Hyva's payment `MethodList` refreshes on address saves and coupon apply/revoke, but **not** on carrier selection — even though `shipping_method_selected` is emitted by `Shipping/MethodList` and `PriceSummary` already refreshes on it. Shipping cost is part of the basket value the gate compares, so a carrier change that moves the basket across the minimum leaves a stale list until some other refresh event fires.

## What

- `Two\GatewayHyva\Magewire\Checkout\Payment\MethodList` extends Hyva's component, merging `shipping_method_selected => refresh` into the inherited listener set.
- Layout swaps the `magewire` argument on `checkout.payment.methods` to the subclass (the documented hyva-checkout customisation seam; the ABN overlay only swaps its child method block's component, so no conflict).
- `dev/stub-hyva` gains a faithful `MethodList` stub so DI compile without Hyva credentials keeps working.
- Unit test pins merge-don't-replace semantics (losing the inherited listeners would silently freeze the list on address/coupon events).

## Testing

`phpunit-10.5.phar` in `php:8.2-cli` docker: 3 tests, 8 assertions, green.

Staging verify after merge: select a carrier that lifts the basket across the 250 EUR ABN minimum and watch the method appear without a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)