### PR TITLE
ABN-458/fix: render payment-terms surcharge line on Hyvä cart page

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -13,5 +13,20 @@
                 <version>1.14.2</version>
             </general>
         </two_hyva>
+        <!--
+            Position the payment-terms surcharge in the Hyvä PHP cart totals.
+            Hyvä sorts the rendered segments by sales/totals_sort (admin:
+            Sales > Sales > Checkout Totals Sort Order); core defaults are
+            subtotal=10, discount=20, shipping=30, tax=40, grand_total=100.
+            Without an entry, two_surcharge sorts to 0 and renders above the
+            subtotal. 39 places it after shipping and immediately before tax
+            (the surcharge's own tax is folded into the Tax line). Ignored by
+            the Luma theme, which orders totals via jsLayout sortOrder.
+        -->
+        <sales>
+            <totals_sort>
+                <two_surcharge>39</two_surcharge>
+            </totals_sort>
+        </sales>
     </default>
 </config>

--- a/view/frontend/layout/checkout_cart_index.xml
+++ b/view/frontend/layout/checkout_cart_index.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<!--
+    Render the Two payment-terms surcharge as a line in the Hyvä cart-page
+    totals. Hyvä's PHP cart renders totals server-side (no KnockoutJS), so
+    the jsLayout component Two_Gateway registers for the Luma cart never
+    fires here — the surcharge was folded into the grand total but shown
+    without its own row (ABN-458). Hyvä's php-cart/totals.phtml loops the
+    `total_segments` and renders every child of checkout.cart.totals; each
+    child gates itself on `segment.code`. Registering our segment template
+    as a child is therefore all that's needed.
+
+    This handle also applies under the Luma theme, but Luma's
+    Magento_Checkout::cart/totals.phtml renders only its jsLayout and never
+    calls getChildHtml(), so this block is inert on Luma — no double line.
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceBlock name="checkout.cart.totals">
+            <block name="two.surcharge.cart.total"
+                   template="Two_GatewayHyva::php-cart/totals/two_surcharge.phtml"/>
+        </referenceBlock>
+    </body>
+</page>

--- a/view/frontend/templates/php-cart/totals/two_surcharge.phtml
+++ b/view/frontend/templates/php-cart/totals/two_surcharge.phtml
@@ -22,12 +22,17 @@ declare(strict_types=1);
  * fee"), `segment.value` the net amount; surcharge tax is folded into the
  * Tax line by the collector. This is the Hyvä counterpart of the Luma
  * cart line registered in Two_Gateway's checkout_cart_index.xml.
+ *
+ * Note: the core rows use `x-html` for the title because some Magento
+ * total titles carry intended markup. Our title is plain text (the
+ * pricing-API description, else "Payment terms fee"), so we use `x-text`
+ * — identical output, no HTML-injection surface.
  */
 ?>
 <template x-if="segment.code === 'two_surcharge'">
     <div class="flex pb-2 my-2 border-b text-md lg:text-sm md:grid md:grid-cols-2 md:w-full border-container two-surcharge-segment">
         <div class="w-7/12 text-left md:w-auto"
-             x-html="segment.title"
+             x-text="segment.title"
         ></div>
         <div class="w-5/12 text-right md:w-auto"
              x-text="hyva.formatPrice(segment.value)"

--- a/view/frontend/templates/php-cart/totals/two_surcharge.phtml
+++ b/view/frontend/templates/php-cart/totals/two_surcharge.phtml
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright © Two.inc All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+/**
+ * Two payment-terms surcharge line for the Hyvä PHP cart totals.
+ *
+ * Rendered inside the x-for segment loop in Hyvä's
+ * Magento_Checkout::php-cart/totals.phtml. Each totals child template
+ * gates itself on the loop's `segment.code`, so this row only appears
+ * when the `two_surcharge` segment is present. The server-side Total
+ * Collector (Two\Gateway\Model\Total\Surcharge) only emits that segment
+ * when the Two payment method and a term are active on the quote, so its
+ * presence is itself the signal that the surcharge applies — the cart
+ * page has no payment-method selector to gate on.
+ *
+ * Mirrors the sibling core totals (discount.phtml / shipping.phtml):
+ * `segment.title` carries the surcharge description (or "Payment terms
+ * fee"), `segment.value` the net amount; surcharge tax is folded into the
+ * Tax line by the collector. This is the Hyvä counterpart of the Luma
+ * cart line registered in Two_Gateway's checkout_cart_index.xml.
+ */
+?>
+<template x-if="segment.code === 'two_surcharge'">
+    <div class="flex pb-2 my-2 border-b text-md lg:text-sm md:grid md:grid-cols-2 md:w-full border-container two-surcharge-segment">
+        <div class="w-7/12 text-left md:w-auto"
+             x-html="segment.title"
+        ></div>
+        <div class="w-5/12 text-right md:w-auto"
+             x-text="hyva.formatPrice(segment.value)"
+        ></div>
+    </div>
+</template>


### PR DESCRIPTION
## What

Renders the Two payment-terms surcharge as its own line in the **Hyvä cart-page totals** (`/checkout/cart` on a Hyvä store view).

## Why

Priyanka reported (ABN-458) that with Two selected and a surcharge-bearing term, the Hyvä cart page included the surcharge in the grand total but showed **no line item** for it.

Root cause: Hyvä's PHP cart renders totals **server-side** — `Magento_Checkout::php-cart/totals.phtml` runs an Alpine `x-for` over `total_segments` and renders every child of `checkout.cart.totals`, each gated on `segment.code`. It does **not** use the KnockoutJS `jsLayout` component that `Two_Gateway` registers for the Luma cart (`checkout_cart_index.xml`, PR #232), so that line never fired on Hyvä. Shipping doesn't hit this because the theme ships a `shipping` child renderer.

## Change

- **`view/frontend/templates/php-cart/totals/two_surcharge.phtml`** — segment template for the `two_surcharge` row, mirroring the core `discount`/`shipping` children (`segment.title` + `hyva.formatPrice(segment.value)`). The collector only emits the segment when Two + a term are active, so its presence is the render signal (no payment-method selector on the cart page to gate on).
- **`view/frontend/layout/checkout_cart_index.xml`** — registers it as a child of `checkout.cart.totals`. Inert on the Luma theme (its totals template renders only `jsLayout`, never `getChildHtml()`).
- **`etc/config.xml`** — `sales/totals_sort/two_surcharge = 39` so the row sorts after shipping and before tax; without it the segment sorts to 0 and renders above the subtotal. Ignored by Luma (jsLayout sortOrder).

## Scope

- PHP cart only — the verified repro and the store's active cart type. GraphQL cart not in scope.
- Reaches both the Two and ABN staging stores (both layer `magento-hyva-extension@staging`).
- Hyvä counterpart of the Luma cart line (`Two_Gateway` #232).

## Verification

- `php -l` clean (run in the staging `magento` container); layout + config XML well-formed.
- All Tailwind utility classes are reused verbatim from the core `discount`/`shipping` total rows (already compiled) — no Tailwind rebuild needed.
- Functional check on the Hyvä cart pending post-deploy (see below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)