### PR TITLE
INF-1601/ci: add auto-tag release + CI-lint workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [staging]
+  pull_request:
+    branches: [staging]
+
+# Cancel in-progress runs for the same ref when a new push lands.
+# Each PR / branch gets its own group so concurrent unrelated work is
+# unaffected.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint (PHP ${{ matrix.php }})
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Two PHP versions bracketing the Magento 2.4 range this Hyvä
+        # extension targets. Kept deliberately lightweight — this is a
+        # syntax gate, not the full PHPUnit/PHPStan/di-compile matrix.
+        php: ["8.1", "8.2"]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: none
+      - name: Lint PHP files
+        run: |
+          find . -name '*.php' \
+            -not -path './vendor/*' \
+            -not -path './node_modules/*' \
+            -print0 | xargs -0 -n1 -P4 php -l > /dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,203 @@
+name: Release
+
+# Auto-tag on green CI: this fires only after the `CI` workflow finishes
+# on `staging`. The job-level guard below then requires that CI actually
+# succeeded before anything is released. This gates releases behind CI
+# rather than firing blindly on every push (the older magento-plugin
+# shape). `workflow_run` triggers off the workflow file on the default
+# branch — which is `staging` here — so this is reliable.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [staging]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-staging
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    # Three guards, any of which stops a release:
+    #   1. CI must have concluded successfully.
+    #   2. The run must be for `staging` (PR-CI runs carry the feature
+    #      branch as head_branch and are ignored — belt-and-braces with
+    #      the `branches:` filter above).
+    #   3. Skip bumpver's own "chore: Bump version" commit, whose push
+    #      re-fires CI and would otherwise loop this workflow forever.
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'staging' &&
+      !startsWith(github.event.workflow_run.head_commit.message, 'chore: Bump version')
+    steps:
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.TWO_INC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.TWO_INC_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v5
+        with:
+          ref: staging
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Skip if HEAD already tagged
+        id: gate
+        run: |
+          set -euo pipefail
+          # Match bare numeric tags (1.14.2 etc.) — the Two-branded
+          # convention on staging. Reject the legacy `abn-*` prefix (that
+          # belongs to the white-label fork on abn-main) so a stale fork
+          # tag pointing at HEAD doesn't suppress a legitimate release.
+          existing=$(git tag --points-at HEAD | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+          if [ -n "$existing" ]; then
+            echo "HEAD already tagged as $existing — nothing to release."
+            echo "skip=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Python
+        if: steps.gate.outputs.skip == '0'
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install bumpver
+        if: steps.gate.outputs.skip == '0'
+        run: pip install bumpver
+
+      - name: Configure git identity
+        if: steps.gate.outputs.skip == '0'
+        run: |
+          git config user.name "two-inc-app[bot]"
+          git config user.email "${{ vars.TWO_INC_APP_ID }}+two-inc-app[bot]@users.noreply.github.com"
+
+      - name: Decide bump level + build release notes
+        # Single pass over `<previous-numeric-tag>..HEAD`:
+        # - Buckets each non-merge commit into Breaking / Features /
+        #   Fixes / Internals / Other based on its conventional-commit
+        #   type, with optional Linear ticket prefix (e.g. INF-123/feat:).
+        # - Writes the bucketed list to release-notes.md so the GitHub
+        #   Release page reflects exactly what triggered the bump level
+        #   (any Breaking entries → major; any Features → minor; else
+        #   patch).
+        if: steps.gate.outputs.skip == '0'
+        id: bump
+        run: |
+          set -euo pipefail
+          prev=$(git tag --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [ -n "$prev" ]; then
+            range="${prev}..HEAD"
+          else
+            range="HEAD"
+          fi
+
+          : > release-notes.md
+          : > /tmp/breaking
+          : > /tmp/features
+          : > /tmp/fixes
+          : > /tmp/internals
+          : > /tmp/other
+
+          while IFS=$'\t' read -r sha subject; do
+            line="- ${subject} (${sha})"
+            if echo "$subject" | grep -qE '^([A-Z]+-[0-9]+/)?[a-z]+(\([^)]+\))?!:|^BREAKING CHANGE:'; then
+              echo "$line" >> /tmp/breaking
+            elif echo "$subject" | grep -qE '^([A-Z]+-[0-9]+/)?feat(\([^)]+\))?:'; then
+              echo "$line" >> /tmp/features
+            elif echo "$subject" | grep -qE '^([A-Z]+-[0-9]+/)?fix(\([^)]+\))?:'; then
+              echo "$line" >> /tmp/fixes
+            elif echo "$subject" | grep -qE '^([A-Z]+-[0-9]+/)?(chore|refactor|ci|docs|test|build|perf|style)(\([^)]+\))?:'; then
+              echo "$line" >> /tmp/internals
+            else
+              echo "$line" >> /tmp/other
+            fi
+          done < <(git log "$range" --no-merges --format='%h%x09%s')
+
+          # Bump level is the highest-severity bucket that's non-empty.
+          if [ -s /tmp/breaking ]; then
+            level=major
+          elif [ -s /tmp/features ]; then
+            level=minor
+          else
+            level=patch
+          fi
+          echo "level=$level" >> "$GITHUB_OUTPUT"
+          echo "Selected bump level: $level (range: $range)"
+
+          # Render notes — only print sections that have entries.
+          {
+            [ -s /tmp/breaking ]  && { echo "## ⚠️ Breaking changes";  cat /tmp/breaking;  echo; }
+            [ -s /tmp/features ]  && { echo "## 🚀 Features";          cat /tmp/features;  echo; }
+            [ -s /tmp/fixes ]     && { echo "## 🐛 Fixes";              cat /tmp/fixes;     echo; }
+            [ -s /tmp/internals ] && { echo "## 🧰 Internals";          cat /tmp/internals; echo; }
+            [ -s /tmp/other ]     && { echo "## Other";                 cat /tmp/other;     echo; }
+          } > release-notes.md
+          # Stash the previous tag so the post-bump step can append a
+          # "Full diff" link with the proper <prev>..<new> range —
+          # the new tag isn't known yet at this point.
+          echo "prev=$prev" >> "$GITHUB_OUTPUT"
+
+          echo "--- release-notes.md preview ---"
+          cat release-notes.md
+
+      - name: Bump version (bumpver — files + commit only)
+        # bumpver.toml is the single source of truth for which files
+        # carry the version (composer.json + etc/config.xml + README.md).
+        # --no-tag-commit --no-push override the tag=true/push=true in
+        # bumpver.toml because we tag and push manually after — the manual
+        # step lets us push under the App token (so downstream workflows
+        # fire) and writes the tag explicitly.
+        if: steps.gate.outputs.skip == '0'
+        env:
+          LEVEL: ${{ steps.bump.outputs.level }}
+        run: bumpver update "--${LEVEL}" --no-tag-commit --no-push
+
+      - name: Read new version
+        if: steps.gate.outputs.skip == '0'
+        id: ver
+        run: |
+          new=$(bumpver show --environ | grep '^CURRENT_VERSION=' | cut -d= -f2)
+          echo "new=$new" >> "$GITHUB_OUTPUT"
+          echo "Released $new"
+
+      - name: Append full-diff link to release notes
+        if: steps.gate.outputs.skip == '0'
+        env:
+          PREV: ${{ steps.bump.outputs.prev }}
+          NEW: ${{ steps.ver.outputs.new }}
+        run: |
+          if [ -n "$PREV" ]; then
+            echo "**Full diff:** [\`${PREV}..${NEW}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${PREV}...${NEW})" >> release-notes.md
+          fi
+
+      - name: Tag + push
+        if: steps.gate.outputs.skip == '0'
+        env:
+          NEW: ${{ steps.ver.outputs.new }}
+        run: |
+          set -euo pipefail
+          git tag -a "${NEW}" -m "Release v${NEW}"
+          # checkout@v5 already wrote the App token into the remote URL,
+          # so this push fires downstream workflows as the App identity
+          # (not GITHUB_TOKEN).
+          git push origin staging
+          git push origin "${NEW}"
+
+      - name: Create GitHub Release
+        if: steps.gate.outputs.skip == '0'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          NEW: ${{ steps.ver.outputs.new }}
+        run: |
+          gh release create "${NEW}" \
+            --target staging \
+            --title "${NEW}" \
+            --notes-file release-notes.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Two Gateway Hyva Extension
 
-- **Two Gateway Module Version**: 1.14.2
+- **Two Gateway Module Version**: 2.0.0
 
 ## Introduction
 

--- a/bumpver.toml
+++ b/bumpver.toml
@@ -1,5 +1,5 @@
 [tool.bumpver]
-current_version = "1.14.2"
+current_version = "2.0.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "chore: Bump version {old_version} -> {new_version}"
 commit = true

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "two-inc/magento2-hyva-checkout",
   "description": "Two Inc Payment Method in Hyva Checkout",
   "type": "magento2-module",
-  "version": "1.14.2",
+  "version": "2.0.0",
   "require": {
     "two-inc/magento2": "^2.0",
     "hyva-themes/magento2-hyva-checkout": "^1.3"

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -10,7 +10,7 @@
     <default>
         <two_hyva>
             <general>
-                <version>1.14.2</version>
+                <version>2.0.0</version>
             </general>
         </two_hyva>
         <!--


### PR DESCRIPTION
## Context

`magento-hyva-extension` has **no release automation** — the `1.14.x` tags were cut by hand running `bumpver` locally. This brings it to parity with `magento-plugin`'s auto-tag-on-green-CI pipeline, and seeds it for the coordinated **2.0.0** launch across the stack (magento-plugin 2.0.0, magento-abn-plugin 2.0.0).

## Changes

- `.github/workflows/ci.yml` (**name: `CI`**): lightweight `php -l` syntax gate on PHP 8.1/8.2. Deliberately not the full PHPUnit/PHPStan/di-compile matrix — magento-plugin's CI is `Two_Gateway`-specific and not portable. A green gate that always passes; can grow later without blocking releases.
- `.github/workflows/release.yml`: fires on `workflow_run` after `CI` succeeds on `staging`; buckets conventional commits for the bump level; bumps via `bumpver`; tags a bare numeric version and cuts a GitHub Release. Rejects legacy `abn-*` tags. Adapted from magento-plugin's release.yml.
- Seed **2.0.0**: `bumpver.toml` `current_version` + `composer.json` + `etc/config.xml` + `README.md` all moved 1.14.2 → 2.0.0. The `current_version` and file strings MUST match or bumpver fails on the next release (the exact bug that broke magento-plugin).

## ⚠️ Required post-merge step (anchors the 2.0.0 launch)

Because `bumpver` always *increases*, a normal auto-release would bump 2.0.0 → 2.1.0. To land the launch on **exactly 2.0.0**, tag the merge commit immediately after merging (before CI→Release completes):

```bash
git fetch origin staging
git tag -a 2.0.0 origin/staging -m "Release 2.0.0"
git push origin 2.0.0
```

The Release workflow's "HEAD already tagged" gate then skips the auto-bump, so 2.0.0 is the launch tag. Every subsequent merge auto-bumps from there (2.0.0 → 2.0.1 / 2.1.0…).

## Scope / Non-goals

- Tags on **`staging`** — hyva's default branch (so `workflow_run` reads the file reliably) and the branch the ABN shops git-sync from. `main` is stale for hyva.
- CI is a syntax gate only; phpunit/jest expansion is a follow-up once validated green.

## Validation

- Both workflows YAML-validated; version strings confirmed consistent at 2.0.0 across all four files.
- Confirmed org vars/secrets (`RUNNER_STANDARD`, `TWO_INC_APP_*`) available and `two-inc-app` bypasses the `staging` push.

## Ticket

- INF-1601