### PR TITLE
INF-1601/ci: retarget release to main + add merge-back

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [staging]
+    branches: [main, staging]
   pull_request:
-    branches: [staging]
+    branches: [main, staging]
 
 # Cancel in-progress runs for the same ref when a new push lands.
 # Each PR / branch gets its own group so concurrent unrelated work is

--- a/.github/workflows/merge-back.yml
+++ b/.github/workflows/merge-back.yml
@@ -1,0 +1,75 @@
+name: Merge back
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: merge-main
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  main-to-staging:
+    name: main → staging
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    if: github.ref_name == 'main'
+    steps:
+      # Use the org GitHub App token — branch protection on `staging`
+      # blocks the default GITHUB_TOKEN from pushing, and a PR opened
+      # with GITHUB_TOKEN wouldn't trigger downstream CI on the new
+      # PR branch.
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.TWO_INC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.TWO_INC_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Fast-forward staging to main (or fall back to a sync PR)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.noreply.github.com"
+          git fetch origin staging
+          # No-op when staging is already at or ahead of main.
+          behind=$(gh api "repos/${REPO}/compare/staging...main" --jq '.ahead_by')
+          if [ "$behind" = "0" ]; then
+            echo "staging already at or ahead of main — nothing to merge back."
+            exit 0
+          fi
+          git checkout staging
+          if git merge --ff-only origin/main; then
+            git push origin staging
+            echo "Fast-forwarded staging to main ($behind commit(s))."
+            exit 0
+          fi
+          # Diverged — open a sync PR instead. Use a deterministic
+          # branch name so repeated runs update the same PR rather
+          # than spawning new ones.
+          echo "staging diverged from main — opening a sync PR."
+          sync_branch="sync/main-to-staging"
+          git checkout -B "$sync_branch" origin/main
+          git push --force-with-lease origin "$sync_branch"
+          existing=$(gh pr list --base staging --head "$sync_branch" --state open --json number --jq '.[0].number // ""')
+          if [ -z "$existing" ]; then
+            gh pr create \
+              --base staging \
+              --head "$sync_branch" \
+              --reviewer brtkwr \
+              --title "chore: sync main → staging" \
+              --body "Auto-sync PR opened by .github/workflows/merge-back.yml after a push to main that couldn't fast-forward into staging. Resolve any conflicts and merge."
+          else
+            echo "Sync PR #$existing already open — updated branch."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,23 @@
 name: Release
 
 # Auto-tag on green CI: this fires only after the `CI` workflow finishes
-# on `staging`. The job-level guard below then requires that CI actually
+# on `main`. The job-level guard below then requires that CI actually
 # succeeded before anything is released. This gates releases behind CI
 # rather than firing blindly on every push (the older magento-plugin
 # shape). `workflow_run` triggers off the workflow file on the default
-# branch — which is `staging` here — so this is reliable.
+# branch — which is `staging` here, where this file lives — so this is
+# reliable; the `branches:` filter then scopes it to CI runs on `main`.
 on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
-    branches: [staging]
+    branches: [main]
 
 permissions:
   contents: write
 
 concurrency:
-  group: release-staging
+  group: release-main
   cancel-in-progress: false
 
 jobs:
@@ -24,14 +25,14 @@ jobs:
     runs-on: ${{ vars.RUNNER_STANDARD }}
     # Three guards, any of which stops a release:
     #   1. CI must have concluded successfully.
-    #   2. The run must be for `staging` (PR-CI runs carry the feature
+    #   2. The run must be for `main` (PR-CI runs carry the feature
     #      branch as head_branch and are ignored — belt-and-braces with
     #      the `branches:` filter above).
     #   3. Skip bumpver's own "chore: Bump version" commit, whose push
     #      re-fires CI and would otherwise loop this workflow forever.
     if: >
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'staging' &&
+      github.event.workflow_run.head_branch == 'main' &&
       !startsWith(github.event.workflow_run.head_commit.message, 'chore: Bump version')
     steps:
       - name: Mint GitHub App token
@@ -43,7 +44,7 @@ jobs:
 
       - uses: actions/checkout@v5
         with:
-          ref: staging
+          ref: main
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
@@ -52,7 +53,7 @@ jobs:
         run: |
           set -euo pipefail
           # Match bare numeric tags (1.14.2 etc.) — the Two-branded
-          # convention on staging. Reject the legacy `abn-*` prefix (that
+          # convention on main. Reject the legacy `abn-*` prefix (that
           # belongs to the white-label fork on abn-main) so a stale fork
           # tag pointing at HEAD doesn't suppress a legitimate release.
           existing=$(git tag --points-at HEAD | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
@@ -188,7 +189,7 @@ jobs:
           # checkout@v5 already wrote the App token into the remote URL,
           # so this push fires downstream workflows as the App identity
           # (not GITHUB_TOKEN).
-          git push origin staging
+          git push origin main
           git push origin "${NEW}"
 
       - name: Create GitHub Release
@@ -198,6 +199,6 @@ jobs:
           NEW: ${{ steps.ver.outputs.new }}
         run: |
           gh release create "${NEW}" \
-            --target staging \
+            --target main \
             --title "${NEW}" \
             --notes-file release-notes.md


### PR DESCRIPTION
## Context

PR #48 wired hyva's new release pipeline to **staging** as a shortcut — at the time `main` looked 63 commits stale. That's no longer true: your **#47** ("Release magento-hyva-extension") synced the ABN features to `main`, and `main` holds the `1.14.x` release tags. The sibling repo **magento-plugin tags from `main`** (`ref: main`, `--target main`). So hyva should too — `main` = prod, `staging` = the integration branch the ABN staging shops git-sync.

## Changes

- **`release.yml`**: repointed the gated `workflow_run` release staging → main — `branches: [main]`, `head_branch == 'main'` guard, `concurrency: release-main`, checkout `ref: main`, `git push origin main`, `gh release --target main`. Kept the CI-gated `workflow_run` shape; only the branch topology changed.
- **`ci.yml`**: `[staging]` → `[main, staging]`. `main` is required so the release's `workflow_run` fires; `staging` retained for PR CI.
- **`merge-back.yml`** (new): `main → staging` via `--ff-only`, else a deterministic `sync/main-to-staging` PR. Inline bash mirroring magento-plugin's merge-back **verbatim** (no external-action dependency) so the deployed `staging` branch stays in sync after each main release/bump.

## Scope / Non-goals

- `workflow_run` fires from the **default-branch** copy of `release.yml` — default is `staging`, so this works because the change lands on staging.
- Does not itself cut a release. The 2.0.0 launch is anchored by a one-time `2.0.0` tag on `main` after the follow-up staging→main Release PR (the current staging-pointed `2.0.0` tag will be deleted and re-cut on main).

## Cutover sequence (after this merges)

1. Merge this → staging (release.yml now targets main; staging pushes stop releasing).
2. Open a **staging → main** "Release" PR → main gets the workflows + the 2.0.0 seed.
3. Immediately tag `2.0.0` on `main` (gate then skips the auto-bump); delete the old staging `2.0.0` tag.
4. merge-back keeps staging synced thereafter.

## Validation

- All three workflows YAML-validated (`yaml.safe_load`).
- merge-back logic copied verbatim from magento-plugin's proven `merge-back.yml`.

## Ticket

- INF-1601