### PR TITLE
INF-1601/fix: pin two-inc/magento2 to ~2.0.0 (minor)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "magento2-module",
   "version": "2.0.0",
   "require": {
-    "two-inc/magento2": "^2.0",
+    "two-inc/magento2": "~2.0.0",
     "hyva-themes/magento2-hyva-checkout": "^1.3"
   },
   "autoload": {


### PR DESCRIPTION
## Context

`two-inc/magento2-hyva-checkout` (this package, the Hyvä engine) is **composer-installed by merchants** and transitively requires the Luma engine `two-inc/magento2`. With `^2.0`, a merchant installing the Hyvä engine could pull a **mismatched Luma minor** (e.g. 2.1.0) that this release wasn't tested against — the "future release causes breakage" risk.

## Changes

- `composer.json`: `two-inc/magento2` `^2.0` → **`~2.0.0`** (locks the transitive Luma engine to the tested 2.0.x line; patches still flow).

## Scope / Non-goals

- **Left as compatibility ranges (deliberately):** `hyva-themes/magento2-hyva-checkout` (`^1.3`, third-party Hyvä framework) and `magento/framework` — pinning these would **reject installation** on legitimate merchant Magento/Hyvä versions.
- **Not touching the ABN overlays' composer.json** (`magento-abn-plugin`): those modules are *unzipped*, not composer-required by merchants, so pinning them protects no one while risking abn's `dev/install.sh` BASE-alias test matrix. Raised separately with Doug as optional.
- Complements the docs pin (docs #751) — the docs `composer require` command is the merchant's primary lever; this is transitive defense-in-depth.

## Tradeoff

Minor-pinning couples releases: a future Luma `2.1.0` requires bumping this to `~2.1.0` + re-release, or the Hyvä engine stays on 2.0.x. That's the intended "no surprise breakages" guarantee.

## Ticket

- INF-1601