### PR TITLE
Release magento-hyva-extension 2.0.0 (2.0 pipeline + engine pin)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [staging]
+  pull_request:
+    branches: [staging]
+
+# Cancel in-progress runs for the same ref when a new push lands.
+# Each PR / branch gets its own group so concurrent unrelated work is
+# unaffected.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint (PHP ${{ matrix.php }})
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Two PHP versions bracketing the Magento 2.4 range this Hyvä
+        # extension targets. Kept deliberately lightweight — this is a
+        # syntax gate, not the full PHPUnit/PHPStan/di-compile matrix.
+        php: ["8.1", "8.2"]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: none
+      - name: Lint PHP files
+        run: |
+          find . -name '*.php' \
+            -not -path './vendor/*' \
+            -not -path './node_modules/*' \
+            -print0 | xargs -0 -n1 -P4 php -l > /dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [staging]
+    branches: [main, staging]
   pull_request:
-    branches: [staging]
+    branches: [main, staging]
 
 # Cancel in-progress runs for the same ref when a new push lands.
 # Each PR / branch gets its own group so concurrent unrelated work is

--- a/.github/workflows/merge-back.yml
+++ b/.github/workflows/merge-back.yml
@@ -1,0 +1,75 @@
+name: Merge back
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: merge-main
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  main-to-staging:
+    name: main → staging
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    if: github.ref_name == 'main'
+    steps:
+      # Use the org GitHub App token — branch protection on `staging`
+      # blocks the default GITHUB_TOKEN from pushing, and a PR opened
+      # with GITHUB_TOKEN wouldn't trigger downstream CI on the new
+      # PR branch.
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.TWO_INC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.TWO_INC_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Fast-forward staging to main (or fall back to a sync PR)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.noreply.github.com"
+          git fetch origin staging
+          # No-op when staging is already at or ahead of main.
+          behind=$(gh api "repos/${REPO}/compare/staging...main" --jq '.ahead_by')
+          if [ "$behind" = "0" ]; then
+            echo "staging already at or ahead of main — nothing to merge back."
+            exit 0
+          fi
+          git checkout staging
+          if git merge --ff-only origin/main; then
+            git push origin staging
+            echo "Fast-forwarded staging to main ($behind commit(s))."
+            exit 0
+          fi
+          # Diverged — open a sync PR instead. Use a deterministic
+          # branch name so repeated runs update the same PR rather
+          # than spawning new ones.
+          echo "staging diverged from main — opening a sync PR."
+          sync_branch="sync/main-to-staging"
+          git checkout -B "$sync_branch" origin/main
+          git push --force-with-lease origin "$sync_branch"
+          existing=$(gh pr list --base staging --head "$sync_branch" --state open --json number --jq '.[0].number // ""')
+          if [ -z "$existing" ]; then
+            gh pr create \
+              --base staging \
+              --head "$sync_branch" \
+              --reviewer brtkwr \
+              --title "chore: sync main → staging" \
+              --body "Auto-sync PR opened by .github/workflows/merge-back.yml after a push to main that couldn't fast-forward into staging. Resolve any conflicts and merge."
+          else
+            echo "Sync PR #$existing already open — updated branch."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,203 @@
+name: Release
+
+# Auto-tag on green CI: this fires only after the `CI` workflow finishes
+# on `staging`. The job-level guard below then requires that CI actually
+# succeeded before anything is released. This gates releases behind CI
+# rather than firing blindly on every push (the older magento-plugin
+# shape). `workflow_run` triggers off the workflow file on the default
+# branch — which is `staging` here — so this is reliable.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [staging]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-staging
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    # Three guards, any of which stops a release:
+    #   1. CI must have concluded successfully.
+    #   2. The run must be for `staging` (PR-CI runs carry the feature
+    #      branch as head_branch and are ignored — belt-and-braces with
+    #      the `branches:` filter above).
+    #   3. Skip bumpver's own "chore: Bump version" commit, whose push
+    #      re-fires CI and would otherwise loop this workflow forever.
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'staging' &&
+      !startsWith(github.event.workflow_run.head_commit.message, 'chore: Bump version')
+    steps:
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.TWO_INC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.TWO_INC_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v5
+        with:
+          ref: staging
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Skip if HEAD already tagged
+        id: gate
+        run: |
+          set -euo pipefail
+          # Match bare numeric tags (1.14.2 etc.) — the Two-branded
+          # convention on staging. Reject the legacy `abn-*` prefix (that
+          # belongs to the white-label fork on abn-main) so a stale fork
+          # tag pointing at HEAD doesn't suppress a legitimate release.
+          existing=$(git tag --points-at HEAD | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+          if [ -n "$existing" ]; then
+            echo "HEAD already tagged as $existing — nothing to release."
+            echo "skip=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Python
+        if: steps.gate.outputs.skip == '0'
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install bumpver
+        if: steps.gate.outputs.skip == '0'
+        run: pip install bumpver
+
+      - name: Configure git identity
+        if: steps.gate.outputs.skip == '0'
+        run: |
+          git config user.name "two-inc-app[bot]"
+          git config user.email "${{ vars.TWO_INC_APP_ID }}+two-inc-app[bot]@users.noreply.github.com"
+
+      - name: Decide bump level + build release notes
+        # Single pass over `<previous-numeric-tag>..HEAD`:
+        # - Buckets each non-merge commit into Breaking / Features /
+        #   Fixes / Internals / Other based on its conventional-commit
+        #   type, with optional Linear ticket prefix (e.g. INF-123/feat:).
+        # - Writes the bucketed list to release-notes.md so the GitHub
+        #   Release page reflects exactly what triggered the bump level
+        #   (any Breaking entries → major; any Features → minor; else
+        #   patch).
+        if: steps.gate.outputs.skip == '0'
+        id: bump
+        run: |
+          set -euo pipefail
+          prev=$(git tag --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [ -n "$prev" ]; then
+            range="${prev}..HEAD"
+          else
+            range="HEAD"
+          fi
+
+          : > release-notes.md
+          : > /tmp/breaking
+          : > /tmp/features
+          : > /tmp/fixes
+          : > /tmp/internals
+          : > /tmp/other
+
+          while IFS=$'\t' read -r sha subject; do
+            line="- ${subject} (${sha})"
+            if echo "$subject" | grep -qE '^([A-Z]+-[0-9]+/)?[a-z]+(\([^)]+\))?!:|^BREAKING CHANGE:'; then
+              echo "$line" >> /tmp/breaking
+            elif echo "$subject" | grep -qE '^([A-Z]+-[0-9]+/)?feat(\([^)]+\))?:'; then
+              echo "$line" >> /tmp/features
+            elif echo "$subject" | grep -qE '^([A-Z]+-[0-9]+/)?fix(\([^)]+\))?:'; then
+              echo "$line" >> /tmp/fixes
+            elif echo "$subject" | grep -qE '^([A-Z]+-[0-9]+/)?(chore|refactor|ci|docs|test|build|perf|style)(\([^)]+\))?:'; then
+              echo "$line" >> /tmp/internals
+            else
+              echo "$line" >> /tmp/other
+            fi
+          done < <(git log "$range" --no-merges --format='%h%x09%s')
+
+          # Bump level is the highest-severity bucket that's non-empty.
+          if [ -s /tmp/breaking ]; then
+            level=major
+          elif [ -s /tmp/features ]; then
+            level=minor
+          else
+            level=patch
+          fi
+          echo "level=$level" >> "$GITHUB_OUTPUT"
+          echo "Selected bump level: $level (range: $range)"
+
+          # Render notes — only print sections that have entries.
+          {
+            [ -s /tmp/breaking ]  && { echo "## ⚠️ Breaking changes";  cat /tmp/breaking;  echo; }
+            [ -s /tmp/features ]  && { echo "## 🚀 Features";          cat /tmp/features;  echo; }
+            [ -s /tmp/fixes ]     && { echo "## 🐛 Fixes";              cat /tmp/fixes;     echo; }
+            [ -s /tmp/internals ] && { echo "## 🧰 Internals";          cat /tmp/internals; echo; }
+            [ -s /tmp/other ]     && { echo "## Other";                 cat /tmp/other;     echo; }
+          } > release-notes.md
+          # Stash the previous tag so the post-bump step can append a
+          # "Full diff" link with the proper <prev>..<new> range —
+          # the new tag isn't known yet at this point.
+          echo "prev=$prev" >> "$GITHUB_OUTPUT"
+
+          echo "--- release-notes.md preview ---"
+          cat release-notes.md
+
+      - name: Bump version (bumpver — files + commit only)
+        # bumpver.toml is the single source of truth for which files
+        # carry the version (composer.json + etc/config.xml + README.md).
+        # --no-tag-commit --no-push override the tag=true/push=true in
+        # bumpver.toml because we tag and push manually after — the manual
+        # step lets us push under the App token (so downstream workflows
+        # fire) and writes the tag explicitly.
+        if: steps.gate.outputs.skip == '0'
+        env:
+          LEVEL: ${{ steps.bump.outputs.level }}
+        run: bumpver update "--${LEVEL}" --no-tag-commit --no-push
+
+      - name: Read new version
+        if: steps.gate.outputs.skip == '0'
+        id: ver
+        run: |
+          new=$(bumpver show --environ | grep '^CURRENT_VERSION=' | cut -d= -f2)
+          echo "new=$new" >> "$GITHUB_OUTPUT"
+          echo "Released $new"
+
+      - name: Append full-diff link to release notes
+        if: steps.gate.outputs.skip == '0'
+        env:
+          PREV: ${{ steps.bump.outputs.prev }}
+          NEW: ${{ steps.ver.outputs.new }}
+        run: |
+          if [ -n "$PREV" ]; then
+            echo "**Full diff:** [\`${PREV}..${NEW}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${PREV}...${NEW})" >> release-notes.md
+          fi
+
+      - name: Tag + push
+        if: steps.gate.outputs.skip == '0'
+        env:
+          NEW: ${{ steps.ver.outputs.new }}
+        run: |
+          set -euo pipefail
+          git tag -a "${NEW}" -m "Release v${NEW}"
+          # checkout@v5 already wrote the App token into the remote URL,
+          # so this push fires downstream workflows as the App identity
+          # (not GITHUB_TOKEN).
+          git push origin staging
+          git push origin "${NEW}"
+
+      - name: Create GitHub Release
+        if: steps.gate.outputs.skip == '0'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          NEW: ${{ steps.ver.outputs.new }}
+        run: |
+          gh release create "${NEW}" \
+            --target staging \
+            --title "${NEW}" \
+            --notes-file release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,23 @@
 name: Release
 
 # Auto-tag on green CI: this fires only after the `CI` workflow finishes
-# on `staging`. The job-level guard below then requires that CI actually
+# on `main`. The job-level guard below then requires that CI actually
 # succeeded before anything is released. This gates releases behind CI
 # rather than firing blindly on every push (the older magento-plugin
 # shape). `workflow_run` triggers off the workflow file on the default
-# branch — which is `staging` here — so this is reliable.
+# branch — which is `staging` here, where this file lives — so this is
+# reliable; the `branches:` filter then scopes it to CI runs on `main`.
 on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
-    branches: [staging]
+    branches: [main]
 
 permissions:
   contents: write
 
 concurrency:
-  group: release-staging
+  group: release-main
   cancel-in-progress: false
 
 jobs:
@@ -24,14 +25,14 @@ jobs:
     runs-on: ${{ vars.RUNNER_STANDARD }}
     # Three guards, any of which stops a release:
     #   1. CI must have concluded successfully.
-    #   2. The run must be for `staging` (PR-CI runs carry the feature
+    #   2. The run must be for `main` (PR-CI runs carry the feature
     #      branch as head_branch and are ignored — belt-and-braces with
     #      the `branches:` filter above).
     #   3. Skip bumpver's own "chore: Bump version" commit, whose push
     #      re-fires CI and would otherwise loop this workflow forever.
     if: >
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'staging' &&
+      github.event.workflow_run.head_branch == 'main' &&
       !startsWith(github.event.workflow_run.head_commit.message, 'chore: Bump version')
     steps:
       - name: Mint GitHub App token
@@ -43,7 +44,7 @@ jobs:
 
       - uses: actions/checkout@v5
         with:
-          ref: staging
+          ref: main
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
@@ -52,7 +53,7 @@ jobs:
         run: |
           set -euo pipefail
           # Match bare numeric tags (1.14.2 etc.) — the Two-branded
-          # convention on staging. Reject the legacy `abn-*` prefix (that
+          # convention on main. Reject the legacy `abn-*` prefix (that
           # belongs to the white-label fork on abn-main) so a stale fork
           # tag pointing at HEAD doesn't suppress a legitimate release.
           existing=$(git tag --points-at HEAD | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
@@ -188,7 +189,7 @@ jobs:
           # checkout@v5 already wrote the App token into the remote URL,
           # so this push fires downstream workflows as the App identity
           # (not GITHUB_TOKEN).
-          git push origin staging
+          git push origin main
           git push origin "${NEW}"
 
       - name: Create GitHub Release
@@ -198,6 +199,6 @@ jobs:
           NEW: ${{ steps.ver.outputs.new }}
         run: |
           gh release create "${NEW}" \
-            --target staging \
+            --target main \
             --title "${NEW}" \
             --notes-file release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,21 @@ jobs:
         id: bump
         run: |
           set -euo pipefail
+          # First-release-of-a-seeded-version. If bumpver.toml's
+          # current_version has never been tagged, release it AS-IS
+          # (mode=seed) — the version files are already at that value, so
+          # bumping would overshoot (e.g. a deliberate 2.0.0 launch would
+          # ship as 2.0.1). Otherwise bump normally (mode=bump). Once the
+          # seeded version is tagged, every later release is a normal bump.
+          seeded=$(grep -E '^current_version' bumpver.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          if git rev-parse -q --verify "refs/tags/${seeded}" >/dev/null 2>&1; then
+            mode=bump
+          else
+            mode=seed
+          fi
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+          echo "Release mode: $mode (seeded current_version: $seeded)"
+
           prev=$(git tag --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
           if [ -n "$prev" ]; then
             range="${prev}..HEAD"
@@ -156,7 +171,9 @@ jobs:
         # bumpver.toml because we tag and push manually after — the manual
         # step lets us push under the App token (so downstream workflows
         # fire) and writes the tag explicitly.
-        if: steps.gate.outputs.skip == '0'
+        # Skipped in seed mode: the files already carry the seeded version,
+        # so there's nothing to bump — we tag it as-is below.
+        if: steps.gate.outputs.skip == '0' && steps.bump.outputs.mode == 'bump'
         env:
           LEVEL: ${{ steps.bump.outputs.level }}
         run: bumpver update "--${LEVEL}" --no-tag-commit --no-push

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Two Gateway Hyva Extension
 
-- **Two Gateway Module Version**: 1.14.2
+- **Two Gateway Module Version**: 2.0.0
 
 ## Introduction
 

--- a/bumpver.toml
+++ b/bumpver.toml
@@ -1,5 +1,5 @@
 [tool.bumpver]
-current_version = "1.14.2"
+current_version = "2.0.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "chore: Bump version {old_version} -> {new_version}"
 commit = true

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "two-inc/magento2-hyva-checkout",
   "description": "Two Inc Payment Method in Hyva Checkout",
   "type": "magento2-module",
-  "version": "1.14.2",
+  "version": "2.0.0",
   "require": {
     "two-inc/magento2": "^2.0",
     "hyva-themes/magento2-hyva-checkout": "^1.3"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "magento2-module",
   "version": "2.0.0",
   "require": {
-    "two-inc/magento2": "^2.0",
+    "two-inc/magento2": "~2.0.0",
     "hyva-themes/magento2-hyva-checkout": "^1.3"
   },
   "autoload": {

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -10,7 +10,7 @@
     <default>
         <two_hyva>
             <general>
-                <version>1.14.2</version>
+                <version>2.0.0</version>
             </general>
         </two_hyva>
         <!--


### PR DESCRIPTION
## Context

Promotes the accumulated 2.0 work from `staging` to `main`, completing the move of hyva's release pipeline onto `main` (matching magento-plugin). `main` had no release workflow and sat at `1.14.2`; `staging` carries the main-targeted workflows, the engine pin, and the 2.0.0 seed.

## What lands on main

- `release.yml` (main-targeted) + `ci.yml` (`[main, staging]`) + `merge-back.yml` — #49
- `two-inc/magento2` pinned to `~2.0.0` — #50
- version files + `bumpver.toml` seeded at `2.0.0` — #48
- `release.yml` **seed-mode** (first release of a seeded version tags it as-is with notes) — #52

## Effect on merge

CI runs on `main` → `release.yml` fires. `current_version` is `2.0.0` and no `2.0.0` tag exists (the earlier stale tag was deleted), so **seed-mode tags `2.0.0` as-is** and publishes a GitHub Release with bucketed `1.14.2..2.0.0` notes (same format as magento-plugin). No bump, no 2.0.1.

Why 2.0.0 is a major: hyva 1.14.2 required `two-inc/magento2: ^1.13.1` (1.x engine); 2.0 requires `~2.0.0` (2.x engine) — a breaking dependency jump.

## Follow-ups (post-merge)

- **Seed-mode cleanup**: once `2.0.0` is tagged, seed-mode goes inert (2.0.0 tagged → normal bump), so it's removed in a follow-up PR to restore exact magento-plugin parity.
- **Packagist**: refresh `two-inc/magento2-hyva-checkout` so `2.0.0` re-publishes from the new commit (it was soft-deleted).
- `merge-back.yml` keeps `staging` in sync going forward.