### PR TITLE
INF-1601/ci: release the seeded version on first release (no overshoot)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,21 @@ jobs:
         id: bump
         run: |
           set -euo pipefail
+          # First-release-of-a-seeded-version. If bumpver.toml's
+          # current_version has never been tagged, release it AS-IS
+          # (mode=seed) — the version files are already at that value, so
+          # bumping would overshoot (e.g. a deliberate 2.0.0 launch would
+          # ship as 2.0.1). Otherwise bump normally (mode=bump). Once the
+          # seeded version is tagged, every later release is a normal bump.
+          seeded=$(grep -E '^current_version' bumpver.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          if git rev-parse -q --verify "refs/tags/${seeded}" >/dev/null 2>&1; then
+            mode=bump
+          else
+            mode=seed
+          fi
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+          echo "Release mode: $mode (seeded current_version: $seeded)"
+
           prev=$(git tag --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
           if [ -n "$prev" ]; then
             range="${prev}..HEAD"
@@ -156,7 +171,9 @@ jobs:
         # bumpver.toml because we tag and push manually after — the manual
         # step lets us push under the App token (so downstream workflows
         # fire) and writes the tag explicitly.
-        if: steps.gate.outputs.skip == '0'
+        # Skipped in seed mode: the files already carry the seeded version,
+        # so there's nothing to bump — we tag it as-is below.
+        if: steps.gate.outputs.skip == '0' && steps.bump.outputs.mode == 'bump'
         env:
           LEVEL: ${{ steps.bump.outputs.level }}
         run: bumpver update "--${LEVEL}" --no-tag-commit --no-push


### PR DESCRIPTION
## Context

You asked for merging to main to **tag 2.0.0 AND generate release notes** natively. The blocker: `release.yml` produces versions by **bumping** `current_version`, so from the seeded `2.0.0` baseline it can only emit `2.0.1` — it cannot tag exactly `2.0.0`. This adds the missing native path.

## Changes

`.github/workflows/release.yml` — new **seed vs bump** mode in the decide step:
- Parse `current_version` from `bumpver.toml`.
- If that version has **never been tagged** → `mode=seed`: tag it **as-is** (skip the `bumpver` bump — the files already carry it) and generate notes.
- Else → `mode=bump`: normal bump (unchanged behaviour).
- The `Bump version` step is now gated on `mode == 'bump'`.

Notes / tag / GitHub-Release steps are untouched — they read `current_version` (the seeded value in seed mode, the bumped value in bump mode), so they Just Work for both. Every release after the seeded one is a normal bump.

## Effect

- **This launch:** after this lands on staging + the stale `2.0.0` tag is removed, merging the staging→main promotion (#51) makes the workflow **tag `2.0.0` and publish a `1.14.2..2.0.0` Release** — natively, no manual anchor/watcher.
- **Future:** `2.0.0 → 2.0.1 → …` normal auto-bumps.
- **Reusable:** magento-abn-plugin has the identical seeded-`2.0.0` situation; same fix applies there (flagged to Doug).

## Sequence (after merge)

1. Merge this → staging (enhanced `release.yml` is now the default-branch copy `workflow_run` uses)
2. I delete the stale `2.0.0` tag (currently on the pre-promotion commit)
3. Merge #51 → workflow seed-mode tags `2.0.0` + notes + Release
4. Refresh Packagist

## Validation

- `release.yml` valid YAML; seed/bump decision logic tested locally against current state (tag present → bump; absent → seed; prev-tag resolves to 1.14.2).

## Ticket

- INF-1601