### PR TITLE
INF-1601/ci: remove seed-mode, restore magento-plugin parity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,21 +93,6 @@ jobs:
         id: bump
         run: |
           set -euo pipefail
-          # First-release-of-a-seeded-version. If bumpver.toml's
-          # current_version has never been tagged, release it AS-IS
-          # (mode=seed) — the version files are already at that value, so
-          # bumping would overshoot (e.g. a deliberate 2.0.0 launch would
-          # ship as 2.0.1). Otherwise bump normally (mode=bump). Once the
-          # seeded version is tagged, every later release is a normal bump.
-          seeded=$(grep -E '^current_version' bumpver.toml | sed -E 's/.*"([^"]+)".*/\1/')
-          if git rev-parse -q --verify "refs/tags/${seeded}" >/dev/null 2>&1; then
-            mode=bump
-          else
-            mode=seed
-          fi
-          echo "mode=$mode" >> "$GITHUB_OUTPUT"
-          echo "Release mode: $mode (seeded current_version: $seeded)"
-
           prev=$(git tag --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
           if [ -n "$prev" ]; then
             range="${prev}..HEAD"
@@ -171,9 +156,7 @@ jobs:
         # bumpver.toml because we tag and push manually after — the manual
         # step lets us push under the App token (so downstream workflows
         # fire) and writes the tag explicitly.
-        # Skipped in seed mode: the files already carry the seeded version,
-        # so there's nothing to bump — we tag it as-is below.
-        if: steps.gate.outputs.skip == '0' && steps.bump.outputs.mode == 'bump'
+        if: steps.gate.outputs.skip == '0'
         env:
           LEVEL: ${{ steps.bump.outputs.level }}
         run: bumpver update "--${LEVEL}" --no-tag-commit --no-push


### PR DESCRIPTION
## Context

Seed-mode (#52) was added so the first release could tag the **seeded** `2.0.0` as-is instead of bumping past it to 2.0.1. It did its job — `2.0.0` is now tagged (`664280f`) with `1.14.2..2.0.0` notes, published, and Latest.

## Changes

Remove the seed-mode block from `.github/workflows/release.yml`:
- the `seeded`/`mode` detection in the decide step
- the `&& steps.bump.outputs.mode == 'bump'` guard on the Bump step (back to `steps.gate.outputs.skip == '0'`)

This restores `release.yml` to the magento-plugin baseline (pre-seed-mode).

## Why it's a safe no-op

With `2.0.0` tagged, the seed check would resolve to `mode=bump` on every future run anyway — seed-mode is now inert. Every release from here is a normal bump (`2.0.0 → 2.0.1 → …`), identical to magento-plugin.

## Note

`main` still carries the (equally inert) seed-mode copy until the next staging→main release promotion syncs this cleanup up; `workflow_run` uses the default-branch (staging) copy, so removing it here is what governs.

## Ticket

- INF-1601