### PR TITLE
Release magento-hyva-extension 2.0.1 (engine pin + pipeline parity)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,21 +93,6 @@ jobs:
         id: bump
         run: |
           set -euo pipefail
-          # First-release-of-a-seeded-version. If bumpver.toml's
-          # current_version has never been tagged, release it AS-IS
-          # (mode=seed) — the version files are already at that value, so
-          # bumping would overshoot (e.g. a deliberate 2.0.0 launch would
-          # ship as 2.0.1). Otherwise bump normally (mode=bump). Once the
-          # seeded version is tagged, every later release is a normal bump.
-          seeded=$(grep -E '^current_version' bumpver.toml | sed -E 's/.*"([^"]+)".*/\1/')
-          if git rev-parse -q --verify "refs/tags/${seeded}" >/dev/null 2>&1; then
-            mode=bump
-          else
-            mode=seed
-          fi
-          echo "mode=$mode" >> "$GITHUB_OUTPUT"
-          echo "Release mode: $mode (seeded current_version: $seeded)"
-
           prev=$(git tag --list --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
           if [ -n "$prev" ]; then
             range="${prev}..HEAD"
@@ -171,9 +156,7 @@ jobs:
         # bumpver.toml because we tag and push manually after — the manual
         # step lets us push under the App token (so downstream workflows
         # fire) and writes the tag explicitly.
-        # Skipped in seed mode: the files already carry the seeded version,
-        # so there's nothing to bump — we tag it as-is below.
-        if: steps.gate.outputs.skip == '0' && steps.bump.outputs.mode == 'bump'
+        if: steps.gate.outputs.skip == '0'
         env:
           LEVEL: ${{ steps.bump.outputs.level }}
         run: bumpver update "--${LEVEL}" --no-tag-commit --no-push


### PR DESCRIPTION
## Context

`2.0.0` (tag `14f0ad1`) is the initial coordinated-launch cut; it matches what's published on Packagist. This promotion cuts **2.0.1**, the first tag to actually contain the engine pin and the main-targeted pipeline.

## What 2.0.1 captures (commits since the 2.0.0 tag)

- `~2.0.0` engine pin (#50) — the real reason for a follow-up release
- main-targeted `release.yml` + `ci.yml` + `merge-back.yml` (#49)
- seed-mode added (#52) then removed (#53) — nets to magento-plugin parity in `release.yml`

## Effect on merge

CI runs on `main` → `release.yml` (seed-mode removed) fires → latest tag is `2.0.0`, range `2.0.0..HEAD` is `ci`/`fix`/`refactor` → **patch bump → tags `2.0.1`** + auto-generates `2.0.0..2.0.1` bucketed notes + GitHub Release (Latest). Packagist auto-syncs 2.0.1.

## Note

This is the staging→main promotion (same direction as #47/#51). `release.yml` is now byte-identical to magento-plugin (seed-mode gone). Future releases are normal bumps.