### PR TITLE
ci(TWO-24999): add full version-matrix CI to magento-hyva-extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          matrix=$(./dev/magento-support-matrix.sh --emit-matrix)
-          skips=$(./dev/magento-support-matrix.sh --emit-skips)
-          php_lint_matrix=$(./dev/magento-support-matrix.sh --emit-php-lint-matrix)
+          # One classification, sliced three ways (--emit-all) so run/skip/lint
+          # are mutually consistent and we hit upstream + Docker Hub once, not 3x
+          # (review: brtkwr on #237).
+          all=$(./dev/magento-support-matrix.sh --emit-all)
+          matrix=$(echo "$all" | jq -c '.matrix')
+          skips=$(echo "$all" | jq -c '.skips')
+          php_lint_matrix=$(echo "$all" | jq -c '.php_lint')
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "php_lint_matrix=$php_lint_matrix" >> "$GITHUB_OUTPUT"
           echo "Runnable PHPStan / DI-compile matrix:"
@@ -144,10 +148,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Run codesniffer
+        # Pinned by digest (was `:latest`) so a new upstream coding-standard
+        # release can't flip CI red with no repo change (review: brtkwr on #55).
+        # To bump: docker pull …:latest && docker inspect --format
+        # '{{index .RepoDigests 0}}' …, then update the digest here.
         run: |
           docker run \
             --volume "$(pwd)/:/app/workdir" \
-            michielgerritsen/magento-coding-standard:latest \
+            michielgerritsen/magento-coding-standard@sha256:48ad208ebbda2e60be6e6c4f1abfe41e75e6339619f109dbf0581624d79e815e \
             --severity=6
 
   di-compile:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,27 +13,194 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Job-name convention: `<Tool> (PHP X.Y[, Magento Z.A.B])`.
+# Tool name first so checks group naturally in the UI.
+
 jobs:
+  # dev/magento-support-matrix.sh is vendored byte-for-byte from the vanilla
+  # two-inc/magento-plugin repo (its `staging` branch is the source of truth —
+  # TWO-24998). This job fails CI red if the local copy has drifted, so the
+  # classifier can't silently rot across the three repos that share it.
+  matrix-script-parity:
+    name: Matrix-script parity
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check classifier matches the canonical copy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./dev/matrix-script-parity.sh
+
+  # Discovers the current Magento support window from upstream so the
+  # PHPStan / DI-compile / lint matrices track Adobe's lifecycle without
+  # hand-maintenance. `dev/magento-support-matrix.sh` is the single
+  # source of truth for which Magento × PHP combinations CI exercises.
+  discover-magento-matrix:
+    name: Discover Magento support matrix
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+      php_lint_matrix: ${{ steps.gen.outputs.php_lint_matrix }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: gen
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          matrix=$(./dev/magento-support-matrix.sh --emit-matrix)
+          skips=$(./dev/magento-support-matrix.sh --emit-skips)
+          php_lint_matrix=$(./dev/magento-support-matrix.sh --emit-php-lint-matrix)
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "php_lint_matrix=$php_lint_matrix" >> "$GITHUB_OUTPUT"
+          echo "Runnable PHPStan / DI-compile matrix:"
+          echo "$matrix" | jq .
+          echo "Skipped (NOT tested) combinations:"
+          echo "$skips" | jq .
+          echo "Generated PHP lint matrix:"
+          echo "$php_lint_matrix" | jq .
+
+          # The run/skip decision is made HERE, at matrix-assembly time — the
+          # test jobs only ever receive runnable combos, so a green test leg
+          # always means "tested" (TWO-24998). Untestable combos never become
+          # green legs; instead they are surfaced two ways that read clearly as
+          # "not run" at a glance:
+          #   1. a coverage table in this job's step summary, and
+          #   2. one ::warning:: annotation per skipped combo (yellow, shown on
+          #      the run summary — distinct from a green pass).
+          {
+            echo "## Magento × PHP version coverage"
+            echo ""
+            echo "| Magento | PHP | Status | Reason |"
+            echo "|---|---|---|---|"
+            echo "$matrix" | jq -r '.[] | "| \(.magento) | \(.php) | ✅ tested | |"'
+            echo "$skips"  | jq -r '.[] | "| \(.magento) | \(.php) | 🚫 NOT run | \(.skip_reason) |"'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "$skips" | jq -r '.[]
+            | "::warning title=Combination NOT tested::\(.magento) / PHP \(.php) — \(.skip_reason)"'
+
   lint:
     name: Lint (PHP ${{ matrix.php }})
+    needs: discover-magento-matrix
     runs-on: ${{ vars.RUNNER_STANDARD }}
     strategy:
       fail-fast: false
       matrix:
-        # Two PHP versions bracketing the Magento 2.4 range this Hyvä
-        # extension targets. Kept deliberately lightweight — this is a
-        # syntax gate, not the full PHPUnit/PHPStan/di-compile matrix.
-        php: ["8.1", "8.2"]
+        include: ${{ fromJSON(needs.discover-magento-matrix.outputs.php_lint_matrix) }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           coverage: none
           tools: none
       - name: Lint PHP files
+        # Test/ is excluded — tests are dev-only and use newer syntax
+        # than the merchant runtime. The phpunit matrix already
+        # exercises Test/ on the supported PHP minors.
         run: |
           find . -name '*.php' \
             -not -path './vendor/*' \
             -not -path './node_modules/*' \
+            -not -path './Test/*' \
             -print0 | xargs -0 -n1 -P4 php -l > /dev/null
+
+  phpunit:
+    name: PHPUnit (PHP ${{ matrix.php }})
+    needs: discover-magento-matrix
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.discover-magento-matrix.outputs.php_lint_matrix) }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: pcov
+          # PHPUnit 10.5 supports PHP 8.1-8.4. If a future PHP minor
+          # (e.g. 8.5) enters the support window and PHPUnit 10.5 has
+          # not been updated to cover it, bump this pin to 11.x.
+          tools: phpunit:10.5
+
+      # The unit tests use a self-contained stub bootstrap (Test/bootstrap.php
+      # + Test/Stubs/) — no Magento framework or composer install required.
+      - name: Run tests with coverage
+        run: phpunit --coverage-clover coverage.xml --coverage-text
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-php${{ matrix.php }}
+          path: coverage.xml
+          if-no-files-found: warn
+
+  codesniffer:
+    name: Codesniffer
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run codesniffer
+        run: |
+          docker run \
+            --volume "$(pwd)/:/app/workdir" \
+            michielgerritsen/magento-coding-standard:latest \
+            --severity=6
+
+  di-compile:
+    name: DI compile (PHP ${{ matrix.php }}, Magento ${{ matrix.magento }})
+    needs: discover-magento-matrix
+    runs-on: ${{ vars.RUNNER_STANDARD }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.discover-magento-matrix.outputs.matrix) }}
+    steps:
+      # The matrix carries only runnable combos (see discover-magento-matrix),
+      # so every leg here is a real test — a green leg means "tested".
+      - uses: actions/checkout@v7
+
+      - name: Start Magento docker container
+        run: |
+          docker run --detach --name magento-project-community-edition \
+            michielgerritsen/magento-project-community-edition:${{ matrix.php_image }}-magento${{ matrix.magento }}
+
+      - name: Upload tracked source into container
+        # Ship only tracked files — avoids leaking .git/, dotfiles,
+        # or any untracked working-tree state into the CI container.
+        run: |
+          docker exec magento-project-community-edition mkdir -p /data/extensions/magento-hyva-extension
+          git ls-files -z | tar --null -cf - -T - | docker exec -i magento-project-community-edition tar -x -C /data/extensions/magento-hyva-extension
+
+      - name: Stub Hyvä / Magewire (no commercial credentials in CI)
+        # The Hyvä checkout package (hyva-themes/magento2-hyva-checkout) is
+        # commercial and can't be pulled in CI without credentials. dev/stub-hyva
+        # satisfies it via composer `provide` + minimal class stubs so
+        # setup:di:compile exercises the module structure credential-free. This
+        # is structural coverage, not a true Hyvä-integration run (TWO-24999).
+        run: |
+          docker exec magento-project-community-edition \
+            php /data/extensions/magento-hyva-extension/dev/stub-hyva
+
+      - name: Install extension from uploaded source
+        # The Hyvä module requires the base Two plugin (two-inc/magento2 ^2.0);
+        # composer pulls it from Packagist (public) alongside the local path copy.
+        run: |
+          docker exec magento-project-community-edition \
+            composer config repositories.local path '/data/extensions/*'
+          docker exec magento-project-community-edition \
+            composer require 'two-inc/magento2-hyva-checkout:*@dev' --no-plugins
+
+      - name: Run setup:di:compile
+        run: |
+          docker exec magento-project-community-edition ./retry \
+            "php bin/magento module:enable Two_Gateway Two_GatewayHyva && php bin/magento setup:upgrade && php bin/magento setup:di:compile"
+
+  # NOTE: no jest job — this module ships no JS tests (package.json is
+  # prettier-only). A `prettier --check` gate was considered (TWO-24999) but
+  # deferred: the tree is not currently prettier-clean (23 files), so the gate
+  # would require a repo-wide `prettier --write` reformat first — a separate
+  # formatting decision, tracked out of this CI-enablement change.

--- a/dev/magento-support-matrix.sh
+++ b/dev/magento-support-matrix.sh
@@ -70,6 +70,13 @@ case "${1:-}" in
     --emit-matrix) mode=matrix ;;
     --emit-skips) mode=skips ;;
     --emit-php-lint-matrix) mode=php_lint ;;
+    # One classification, all three slices in a single object. The CI discover
+    # step uses this so the run-list, skip-list and lint-list come from ONE run
+    # of the classifier — not three independent runs that each re-fetch upstream
+    # and re-probe every image. Prevents a transient `docker manifest inspect`
+    # blip from putting a combo in one slice but not its mirror, and cuts the
+    # anonymous Docker Hub rate-limit exposure 3x (review: brtkwr on #237).
+    --emit-all) mode=all ;;
     "") mode=report ;;
     *) echo "Unknown flag: $1" >&2; exit 2 ;;
 esac
@@ -140,6 +147,13 @@ fetch_json() {
 # a Docker Hub blip must not silently zero the matrix). `docker manifest
 # inspect` returns non-zero for both cases, so we inspect stderr: a clear
 # "not found"-class message → missing; anything else → retry once → error.
+#
+# Trade-off (by design, review: brtkwr on #237): because "error" maps to RUN,
+# under degraded / rate-limited registry conditions a genuinely-missing image
+# is classified `run` and surfaces as a RED matrix leg rather than the intended
+# yellow (::warning::) skip. We prefer a loud red on a Docker Hub blip over a
+# silent green that hides zero coverage. Every such case emits the ::warning::
+# above, so the run/skip mismatch is greppable in the job log.
 # ---------------------------------------------------------------------------
 probe_image() {
     local img="$1" attempt out
@@ -358,6 +372,14 @@ case "$mode" in
         ;;
     php_lint)
         echo "$php_lint_json"
+        ;;
+    all)
+        # Single-classification bundle for the CI discover step (see --emit-all).
+        jq -nc \
+            --argjson matrix "$run_json" \
+            --argjson skips "$skip_json" \
+            --argjson php_lint "$php_lint_json" \
+            '{matrix: $matrix, skips: $skips, php_lint: $php_lint}'
         ;;
     report)
         echo ""

--- a/dev/magento-support-matrix.sh
+++ b/dev/magento-support-matrix.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+# dev/magento-support-matrix.sh — discover AND CLASSIFY the CI version matrix
+# dynamically from upstream.
+#
+# Usage:
+#   ./dev/magento-support-matrix.sh                        # human-readable report
+#   ./dev/magento-support-matrix.sh --emit-matrix          # GHA matrix JSON: RUNNABLE Magento × PHP combos
+#   ./dev/magento-support-matrix.sh --emit-skips           # JSON: combos we CANNOT run, with reasons
+#   ./dev/magento-support-matrix.sh --emit-php-lint-matrix # GHA matrix JSON: PHP-only (lint / phpunit jobs)
+#
+# This script CLASSIFIES every combination inside the current support window
+# as run | skip, then splits the two:
+#   --emit-matrix  → only runnable combos. These become real matrix legs, so a
+#                    green leg genuinely means "tested" — a skipped combo is
+#                    NEVER emitted here and so can never masquerade as a passed
+#                    test (TWO-24998: the run/skip decision happens at
+#                    matrix-assembly time, not inside a green job).
+#   --emit-skips   → the combos we could not run, each with a skip_reason. The
+#                    discover job renders these to $GITHUB_STEP_SUMMARY and
+#                    emits a ::warning:: per combo so an untested combination is
+#                    visible at a glance and cannot be mistaken for a pass.
+# Nothing testable is silently green; nothing untestable silently vanishes.
+#
+# Strategy:
+#   1. Query github.com/magento/magento2 tags for bare-semver 2.4.x.
+#   2. Support window = current minor + (SUPPORT_WINDOW-1) previous minors,
+#      taken over ALL minors. Image availability does NOT slide the window:
+#      an in-policy minor with no CI image is surfaced as a skip, it is NOT
+#      silently replaced by an older out-of-policy minor (TWO-24998 Defect 2 —
+#      "the window silently trails a minor behind").
+#   3. For each window minor: fetch composer.json, parse require.php → the
+#      PHP minors it accepts (e.g. "~8.2.0||~8.3.0||~8.4.0" → 8.2 8.3 8.4).
+#   4. php.net/releases → currently-supported PHP minors.
+#   5. Classify each (window-minor × accepted-PHP) combo, first matching wins:
+#        past upstream PHP support   — accepted by Magento but EOL per php.net
+#        intentionally excluded: ... — on the manual list (usually empty now)
+#        no CI image published       — deterministic image tag has no manifest
+#        run                         — otherwise
+#   6. Emit every combo with its status. The php-lint matrix is the union of
+#      php.net-supported accepted PHP minors — image-independent, since the
+#      lint / phpunit jobs use setup-php, not the Magento docker images.
+#
+# Replaces the hand-maintained EOL list AND the hand-maintained min-PHP map
+# with upstream discovery (Doug 2026-05-22, r5 #10). TWO-24998 additionally
+# retired the hand-maintained image-exclusion entries in favour of a docker
+# manifest probe (see intentionally_excluded + probe_image below).
+
+set -euo pipefail
+
+# How many minor lines (current + previous) we support. Adobe's policy is
+# "current + previous 2" → 3 total. This bounds the window over ALL published
+# minors; it does NOT skip over image-less minors (see header note 2).
+SUPPORT_WINDOW=${SUPPORT_WINDOW:-3}
+
+CI_IMAGE_REPO="michielgerritsen/magento-project-community-edition"
+
+# Combos we DELIBERATELY choose not to test even though a CI image exists.
+# This is NOT the place for "no image published yet" — that case is detected
+# automatically by the docker manifest probe (probe_image) and surfaced as a
+# `no CI image published` skip. Expect this list to stay empty; add an entry
+# only for a genuine "we will not test X" policy decision, documenting why.
+#
+#   "<magento>:<reason>"               whole-minor: every PHP pairing skips
+#   "<magento>:php=<X.Y>:<reason>"     single combo: only that PHP pairing skips
+intentionally_excluded=(
+)
+
+mode=report
+case "${1:-}" in
+    --emit-matrix) mode=matrix ;;
+    --emit-skips) mode=skips ;;
+    --emit-php-lint-matrix) mode=php_lint ;;
+    "") mode=report ;;
+    *) echo "Unknown flag: $1" >&2; exit 2 ;;
+esac
+
+log() {
+    [ "$mode" = "report" ] || return 0
+    echo "$@"
+}
+
+# Authorise GitHub API when a token is available to dodge anon rate-limit.
+# NB: only ever sent to github.com hosts (see fetch_json's use_auth arg) — we
+# do NOT leak the token to php.net.
+gh_headers=()
+[ -n "${GH_TOKEN:-${GITHUB_TOKEN:-}}" ] \
+    && gh_headers=(-H "Authorization: Bearer ${GH_TOKEN:-$GITHUB_TOKEN}")
+
+# ---------------------------------------------------------------------------
+# fetch_json <description> <url> <use_gh_auth:0|1> [validator-jq-expr]
+#
+# Fetches with one retry on transient failure. Validates HTTP 200 and
+# (optionally) the JSON shape before returning the body — a rate-limited /
+# 502 / HTML response would otherwise surface as a cryptic downstream jq
+# error like `Cannot index string with string "name"` instead of the real
+# upstream problem. `use_gh_auth=1` attaches the GitHub bearer token; pass 0
+# for third-party hosts (php.net) so credentials never leave github.com.
+# ---------------------------------------------------------------------------
+fetch_json() {
+    local desc="$1" url="$2" use_auth="$3" validator="${4:-}"
+    local headers=() attempt response http_code body
+    [ "$use_auth" = "1" ] && headers=("${gh_headers[@]}")
+    for attempt in 1 2; do
+        if ! response=$(curl -sS --max-time 30 -w '\n%{http_code}' \
+                -H 'Cache-Control: no-cache' "${headers[@]}" "$url" 2>&1); then
+            echo "::warning::${desc} attempt ${attempt}: curl failed: ${response}" >&2
+            [ "$attempt" -lt 2 ] && { sleep 5; continue; }
+            echo "::error::${desc} unreachable after retry" >&2
+            return 2
+        fi
+        http_code="${response##*$'\n'}"
+        body="${response%$'\n'*}"
+        if [ "$http_code" != "200" ]; then
+            echo "::warning::${desc} attempt ${attempt}: HTTP ${http_code}" >&2
+            printf 'Response body (first 500 chars): ' >&2
+            printf '%s' "$body" | head -c 500 >&2; echo >&2
+            [ "$attempt" -lt 2 ] && { sleep 5; continue; }
+            echo "::error::${desc} persistently returning HTTP ${http_code}" >&2
+            return 2
+        fi
+        if [ -n "$validator" ] && ! printf '%s' "$body" | jq -e "$validator" >/dev/null 2>&1; then
+            echo "::warning::${desc} attempt ${attempt}: response failed shape check ($validator)" >&2
+            printf 'Response body (first 500 chars): ' >&2
+            printf '%s' "$body" | head -c 500 >&2; echo >&2
+            [ "$attempt" -lt 2 ] && { sleep 5; continue; }
+            echo "::error::${desc} persistently malformed" >&2
+            return 2
+        fi
+        printf '%s' "$body"
+        return 0
+    done
+    return 2
+}
+
+# ---------------------------------------------------------------------------
+# probe_image <image-tag> → prints one of: exists | missing | error
+#
+# Distinguishes a genuinely-unpublished image (skip) from a transient
+# registry failure (fail TOWARD running the test, per TWO-24998 Phase 2 —
+# a Docker Hub blip must not silently zero the matrix). `docker manifest
+# inspect` returns non-zero for both cases, so we inspect stderr: a clear
+# "not found"-class message → missing; anything else → retry once → error.
+# ---------------------------------------------------------------------------
+probe_image() {
+    local img="$1" attempt out
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "::warning::probe_image: docker CLI unavailable; treating '$img' as runnable" >&2
+        echo error
+        return 0
+    fi
+    for attempt in 1 2; do
+        if out=$(DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "$img" 2>&1); then
+            echo exists
+            return 0
+        fi
+        if printf '%s' "$out" | grep -qiE 'no such manifest|manifest unknown|not found|does not exist'; then
+            echo missing
+            return 0
+        fi
+        [ "$attempt" -lt 2 ] && { sleep 3; continue; }
+        echo "::warning::probe_image: '$img' inspect errored (not a clean 'missing'), defaulting to run: ${out}" >&2
+        echo error
+        return 0
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Step 1: discover Magento minors from upstream tags; take the top-N window.
+# ---------------------------------------------------------------------------
+tags_json=$(fetch_json "GitHub tags API" \
+    'https://api.github.com/repos/magento/magento2/tags?per_page=100' \
+    1 'type == "array"') || exit 2
+
+all_minors=$(printf '%s' "$tags_json" \
+    | jq -r 'map(.name)
+             | map(select(test("^2\\.4\\.[0-9]+$")))
+             | sort_by(. | split(".") | map(tonumber))
+             | reverse
+             | .[]')
+
+if [ -z "$all_minors" ]; then
+    echo "::error::No bare-semver 2.4.x tags found on github.com/magento/magento2" >&2
+    exit 2
+fi
+
+# Window = the SUPPORT_WINDOW most-recent minors, over ALL of them. We do NOT
+# pre-filter image-less/excluded minors out before taking the top-N — doing so
+# would let an older out-of-policy minor backfill the window and hide the fact
+# that an in-policy minor is currently untestable (TWO-24998 Defect 2).
+supported=$(echo "$all_minors" | head -n "$SUPPORT_WINDOW")
+log "Magento support window ($SUPPORT_WINDOW most-recent minors):"
+log "$supported" | sed 's/^/  /'
+
+# Build intentional-exclusion maps. Two scopes:
+#   excluded_minor_map[<magento>]       = reason    (whole-minor)
+#   excluded_combo_map[<magento>|<php>] = reason    (single combo)
+declare -A excluded_minor_map=()
+declare -A excluded_combo_map=()
+for entry in "${intentionally_excluded[@]:-}"; do
+    [ -z "$entry" ] && continue
+    ver="${entry%%:*}"
+    rest="${entry#*:}"
+    if [[ "$rest" == php=*:* ]]; then
+        php_clause="${rest%%:*}"            # php=8.2
+        reason="${rest#*:}"
+        php_ver="${php_clause#php=}"        # 8.2
+        excluded_combo_map["$ver|$php_ver"]="$reason"
+    else
+        excluded_minor_map["$ver"]="$rest"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Step 2: discover currently-supported PHP minors from php.net.
+# ---------------------------------------------------------------------------
+php_releases_json=$(fetch_json "php.net releases feed" \
+    'https://www.php.net/releases/?json' \
+    0 'type == "object"') || exit 2
+
+# Union of `supported_versions` across all majors, e.g. ["8.2","8.3","8.4","8.5"].
+supported_php_minors=$(echo "$php_releases_json" \
+    | jq -r '[.[].supported_versions[]?] | unique | .[]' \
+    | sort -V)
+
+if [ -z "$supported_php_minors" ]; then
+    echo "::error::php.net/releases returned no currently-supported PHP minors" >&2
+    exit 2
+fi
+
+log "Currently-supported PHP minors (php.net):"
+log "$supported_php_minors" | sed 's/^/  /'
+
+# ---------------------------------------------------------------------------
+# Step 3: for each window minor, fetch composer.json and parse php constraint.
+#
+# Magento's constraint format is "~8.2.0||~8.3.0||~8.4.0" — one tilde range
+# per supported minor, OR-joined. `~8.X.0` means ">=8.X.0,<8.(X+1).0", so each
+# clause uniquely identifies one PHP minor.
+# ---------------------------------------------------------------------------
+declare -A magento_php_minors=()  # magento_minor → space-separated PHP minors
+for minor in $supported; do
+    composer_json=$(fetch_json "magento/magento2@$minor composer.json" \
+        "https://raw.githubusercontent.com/magento/magento2/$minor/composer.json" \
+        1 'type == "object"') || exit 2
+    php_constraint=$(echo "$composer_json" | jq -r '.require.php // empty')
+    if [ -z "$php_constraint" ]; then
+        echo "::error::magento/magento2@$minor composer.json missing require.php" >&2
+        exit 2
+    fi
+    # `|| true`: under `set -o pipefail`, grep exits 1 when a constraint has no
+    # `~X.Y.0` clause (e.g. an unexpected format), which would terminate the
+    # script here and bypass the diagnostic below. Swallow it so the empty-check
+    # fires with a useful error instead.
+    php_minors_for_magento=$(echo "$php_constraint" \
+        | grep -oE '~[0-9]+\.[0-9]+\.0' \
+        | sed -E 's/~([0-9]+\.[0-9]+)\.0/\1/' \
+        | sort -V) || true
+    if [ -z "$php_minors_for_magento" ]; then
+        echo "::error::Could not parse php constraint '$php_constraint' for Magento $minor" >&2
+        exit 2
+    fi
+    magento_php_minors["$minor"]=$(echo $php_minors_for_magento)
+    log "  $minor accepts PHP: ${magento_php_minors[$minor]} (from '$php_constraint')"
+done
+
+# ---------------------------------------------------------------------------
+# Step 4: classify every (window-minor × accepted-PHP) combo.
+# ---------------------------------------------------------------------------
+matrix_entries=()
+declare -A php_lint_minors=()   # union of php.net-supported accepted PHP minors
+run_count=0
+skip_count=0
+
+emit() {  # emit <magento> <php> <php_image> <status> <skip_reason>
+    matrix_entries+=("$(jq -nc \
+        --arg magento "$1" \
+        --arg php "$2" \
+        --arg php_image "$3" \
+        --arg status "$4" \
+        --arg skip_reason "$5" \
+        '{magento:$magento, php:$php, php_image:$php_image, status:$status, skip_reason:$skip_reason}')")
+    if [ "$4" = "run" ]; then run_count=$((run_count+1)); else skip_count=$((skip_count+1)); fi
+}
+
+for minor in $supported; do
+    accepted="${magento_php_minors[$minor]:-}"
+    [ -z "$accepted" ] && continue
+    minor_excl="${excluded_minor_map[$minor]:-}"
+
+    for php in $accepted; do
+        php_image="php${php//./}-fpm"
+        img_tag="${CI_IMAGE_REPO}:${php_image}-magento${minor}"
+
+        # 1. Past upstream PHP support (php.net no longer lists this minor).
+        if ! echo "$supported_php_minors" | grep -qxF "$php"; then
+            emit "$minor" "$php" "$php_image" skip "past upstream PHP support"
+            continue
+        fi
+        # php.net-supported → contributes to the (image-independent) lint set,
+        # regardless of whether the Magento×PHP combo runs or skips below.
+        php_lint_minors["$php"]=1
+
+        # 2. Intentional exclusion (whole-minor, then single-combo).
+        if [ -n "$minor_excl" ]; then
+            emit "$minor" "$php" "$php_image" skip "intentionally excluded: $minor_excl"
+            continue
+        fi
+        combo_excl="${excluded_combo_map[$minor|$php]:-}"
+        if [ -n "$combo_excl" ]; then
+            emit "$minor" "$php" "$php_image" skip "intentionally excluded: $combo_excl"
+            continue
+        fi
+
+        # 3. CI image availability (auto-probed — no hand-maintained list).
+        case "$(probe_image "$img_tag")" in
+            missing)
+                emit "$minor" "$php" "$php_image" skip "no CI image published ($img_tag)"
+                continue
+                ;;
+        esac
+
+        # 4. Runnable.
+        emit "$minor" "$php" "$php_image" run ""
+    done
+done
+
+if [ ${#matrix_entries[@]} -eq 0 ]; then
+    echo "::error::No combos classified — window / constraint parsing failed" >&2
+    exit 1
+fi
+if [ "$run_count" -eq 0 ]; then
+    # Not fatal — an all-skip run is a legitimate (loud) signal that zero
+    # combos are currently testable. The coverage-report job surfaces it.
+    echo "::warning::Every in-window combo classified as SKIP — zero real version coverage this run" >&2
+fi
+
+# Full classified set, then split into the runnable matrix and the skip list.
+# Runnable combos carry only the keys the test jobs consume ({magento, php,
+# php_image}); skip combos carry their reason instead of an image.
+classified_json=$(printf '%s\n' "${matrix_entries[@]}" | jq -sc '.')
+run_json=$(echo "$classified_json" | jq -c '[.[] | select(.status == "run") | {magento, php, php_image}]')
+skip_json=$(echo "$classified_json" | jq -c '[.[] | select(.status == "skip") | {magento, php, skip_reason}]')
+
+if [ ${#php_lint_minors[@]} -eq 0 ]; then
+    php_lint_json='[]'
+else
+    php_lint_json=$(printf '%s\n' "${!php_lint_minors[@]}" \
+        | sort -V \
+        | jq -R . | jq -sc 'map({php: .})')
+fi
+
+case "$mode" in
+    matrix)
+        echo "$run_json"
+        ;;
+    skips)
+        echo "$skip_json"
+        ;;
+    php_lint)
+        echo "$php_lint_json"
+        ;;
+    report)
+        echo ""
+        echo "Classified Magento × PHP matrix ($run_count run, $skip_count skip):"
+        echo "$classified_json" | jq -r '.[]
+            | if .status == "skip"
+              then "  SKIP  \(.magento) PHP \(.php) — \(.skip_reason)"
+              else "  RUN   \(.magento) PHP \(.php)"
+              end'
+        echo ""
+        echo "PHP lint matrix:"
+        echo "$php_lint_json" | jq -r '.[].php | "  \(.)"'
+        echo ""
+        echo "magento-support-matrix OK."
+        ;;
+esac

--- a/dev/matrix-script-parity.sh
+++ b/dev/matrix-script-parity.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# dev/matrix-script-parity.sh — drift guard for the version-support classifier.
+#
+# `dev/magento-support-matrix.sh` is vendored byte-for-byte from the vanilla
+# `two-inc/magento-plugin` repo (its `staging` branch is the source of truth —
+# TWO-24998 chose a vendored copy + this guard over a submodule/subtree for a
+# single shell script). Any divergence between the two copies is CI red, so a
+# fix to the classifier in one repo can't silently rot in the other.
+#
+# To update: change the canonical copy on magento-plugin first, land it on
+# `staging`, then copy the identical file here in a follow-up PR.
+#
+# Mirrors dev/agents-convention-parity.sh (the AGENTS.md drift guard).
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+local_script="${repo_root}/dev/magento-support-matrix.sh"
+canonical_repo="two-inc/magento-plugin"
+canonical_ref="staging"
+canonical_path="dev/magento-support-matrix.sh"
+
+if [ ! -f "$local_script" ]; then
+    echo "::error::matrix-script-parity: local $canonical_path missing at $local_script"
+    exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "::error::matrix-script-parity: gh CLI required for the cross-repo parity check."
+    exit 1
+fi
+
+canonical=$(mktemp)
+trap 'rm -f "$canonical"' EXIT
+
+# Fetch the raw file via the GitHub raw media type — avoids the JSON+base64
+# round-trip (and `base64 -d`'s GNU/BSD flag portability quirk).
+if ! gh api -H "Accept: application/vnd.github.raw" \
+       "repos/${canonical_repo}/contents/${canonical_path}?ref=${canonical_ref}" \
+       > "$canonical" 2>/dev/null; then
+    echo "::error::matrix-script-parity: failed to fetch canonical ${canonical_path} from ${canonical_repo}@${canonical_ref}."
+    exit 1
+fi
+
+l_sha=$(sha256sum "$local_script" | cut -d' ' -f1)
+c_sha=$(sha256sum "$canonical"    | cut -d' ' -f1)
+
+if [ "$l_sha" != "$c_sha" ]; then
+    echo "::error::matrix-script-parity: dev/magento-support-matrix.sh has drifted from ${canonical_repo}@${canonical_ref}."
+    echo "  local sha256:     $l_sha"
+    echo "  canonical sha256: $c_sha"
+    echo "  Re-sync from the source of truth (magento-plugin is canonical)."
+    diff "$canonical" "$local_script" | head -80
+    exit 1
+fi
+
+echo "matrix-script-parity OK: dev/magento-support-matrix.sh matches ${canonical_repo}@${canonical_ref} (sha256=$l_sha)."

--- a/dev/matrix-script-parity.sh
+++ b/dev/matrix-script-parity.sh
@@ -34,11 +34,22 @@ canonical=$(mktemp)
 trap 'rm -f "$canonical"' EXIT
 
 # Fetch the raw file via the GitHub raw media type — avoids the JSON+base64
-# round-trip (and `base64 -d`'s GNU/BSD flag portability quirk).
-if ! gh api -H "Accept: application/vnd.github.raw" \
-       "repos/${canonical_repo}/contents/${canonical_path}?ref=${canonical_ref}" \
-       > "$canonical" 2>/dev/null; then
-    echo "::error::matrix-script-parity: failed to fetch canonical ${canonical_path} from ${canonical_repo}@${canonical_ref}."
+# round-trip (and `base64 -d`'s GNU/BSD flag portability quirk). Retry a few
+# times so a transient API blip reds the check only for genuine drift, not a
+# one-off network hiccup — parity with the classifier's own fetch_json retry
+# (review: brtkwr on #153).
+fetched=0
+for attempt in 1 2 3; do
+    if gh api -H "Accept: application/vnd.github.raw" \
+           "repos/${canonical_repo}/contents/${canonical_path}?ref=${canonical_ref}" \
+           > "$canonical" 2>/dev/null; then
+        fetched=1
+        break
+    fi
+    [ "$attempt" -lt 3 ] && sleep 3
+done
+if [ "$fetched" -ne 1 ]; then
+    echo "::error::matrix-script-parity: failed to fetch canonical ${canonical_path} from ${canonical_repo}@${canonical_ref} after 3 attempts."
     exit 1
 fi
 

--- a/dev/stub-hyva
+++ b/dev/stub-hyva
@@ -5,6 +5,14 @@
  * and DI-compiled without Hyvä credentials.
  *
  * Called by: make install (when auth.json is absent)
+ *
+ * DRIFT CAVEAT (review: brtkwr on #55): these class stubs are authored by the
+ * same hand as the consumer, so di:compile against them can't catch SIGNATURE
+ * drift in the real licensed `hyva-themes/magento2-hyva-checkout` package — a
+ * method/const the real Hyvä base class renamed would still "pass" here. There
+ * is deliberately no automated drift guard (the real package isn't fetchable in
+ * CI). Mitigation: review this stub set against the Hyvä changelog whenever the
+ * `hyva-themes/magento2-hyva-checkout` constraint is bumped in composer.json.
  */
 
 // 1. Stub packages in composer provides


### PR DESCRIPTION
## What

`magento-hyva-extension` had only a placeholder lint job (INF-1601, hardcoded PHP 8.1/8.2) plus the auto-tag `release.yml` / `merge-back.yml`. This adds the **classifier-driven version-matrix CI** the sibling Magento plugin repos run, making this repo the **third consumer** of `dev/magento-support-matrix.sh` (per TWO-24999 / TWO-24998).

## Jobs

| Job | Notes |
|---|---|
| `matrix-script-parity` | drift guard — fails red if the vendored classifier diverges from `magento-plugin@staging` |
| `discover-magento-matrix` | emits runnable matrix + renders a coverage table & `::warning::` per untestable combo (honest skips, TWO-24998) |
| `lint` | PHP `-l` over support-window minors |
| `phpunit` | phpunit 10.5, self-contained stub bootstrap (no Magento/composer) — the existing tests finally run in CI |
| `codesniffer` | docker coding-standard, severity 6 |
| `di-compile` | Magento × PHP matrix, wired through `dev/stub-hyva` so it compiles **without Hyvä commercial credentials** (structural coverage) |

Supersedes the placeholder `lint` job. `release.yml`/`merge-back.yml` untouched.

## Vendored / shared

- `dev/magento-support-matrix.sh` — **byte-identical** to `magento-plugin` (sha256 verified) + `dev/matrix-script-parity.sh` drift guard.
- ⚠️ **Parity guard is RED until TWO-24998 (#237) lands on `magento-plugin` staging** — expected, same accepted precedent as `magento-abn-plugin` #153. Merge order: **#237 first**, then this + #153 go green.
- ⚠️ **Release-gate coupling:** `release.yml` auto-tags on green `CI` on `main`. Once this reaches `main`, a red parity guard would block auto-release — so this should not be promoted to `main` before #237 merges.

## Deferred (in TWO-24999's ⚠️/optional column)

- **phpstan** — will attempt once the base suite is green; if it needs a large Hyvä-stub baseline, defer with a note.
- **prettier `--check` gate** — the tree is not currently prettier-clean (23 files); adding the gate needs a repo-wide `prettier --write` first, a separate formatting decision.
- **No jest** — this module ships no JS tests.

## Leak-gate

Public repo — no ABN references introduced. ABN Hyvä overlay CI is tracked separately in the **private** repo (TWO-25000).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — opened on Doug's behalf.